### PR TITLE
Store entity fix (parallel upload for multiply typed items)

### DIFF
--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -1077,13 +1077,11 @@ class OSW(BaseModel):
         )
 
         class UploadObject(BaseModel):
-            entity: model.Entity
+            entity: OswBaseModel
+            # Actually model.Entity but this causes the "type" error
             namespace: Optional[str]
             index: int
             overwrite_class_param: OSW.OverwriteClassParam
-
-            class Config:
-                arbitrary_types_allowed = True  # Disables silent casting
 
         upload_object_list: List[UploadObject] = []
 

--- a/src/osw/express.py
+++ b/src/osw/express.py
@@ -585,9 +585,11 @@ class DownloadFileResult(FileResult, LocalFileController):
                     domain=data.get("domain"),
                     cred_mngr=data.get("cred_mngr"),
                 )
-            title = "File:" + url_or_title.split("File:")[-1]
+            title: str = "File:" + url_or_title.split("File:")[-1]
             file = data.get("osw_express").load_entity(title)
-            wf = file.cast(WikiFileController, osw=data.get("osw_express"))
+            wf: WikiFileController = file.cast(
+                WikiFileController, osw=data.get("osw_express")
+            )
             """The file controller"""
             if data.get("target_fp").exists() and not data.get("overwrite"):
                 raise FileExistsError(


### PR DESCRIPTION
Before: 
* Solely, sequential upload is possible if items to be uploaded have diverse types, resulting in annoying save times. (for each type a parallel upload is performed, resulting essentially in sequential uploads)
Now:
* Upload items are first collected in common list then uploaded asynchronously unless parallel=false is actively set.