### PR TITLE
fix(ci): register pytest options in rootdir conftest for pytest 9.0

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,16 @@
+"""Root conftest for pytest.
+
+``pytest_addoption`` must live in the *rootdir* conftest (or a plugin):
+since pytest 9.0 the hook is no longer picked up from a subdirectory
+conftest (e.g. ``tests/conftest.py``) reached only via ``testpaths``,
+which caused "unrecognized arguments: --wiki_domain ..." in CI. The
+option-backed fixtures stay in ``tests/conftest.py``.
+"""
+
+
+def pytest_addoption(parser):
+    parser.addoption("--wiki_domain", action="store")
+    parser.addoption("--wiki_username", action="store")
+    parser.addoption("--wiki_password", action="store")
+    parser.addoption("--db_username", action="store")
+    parser.addoption("--db_password", action="store")

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -9,13 +9,9 @@
 
 import pytest
 
-
-def pytest_addoption(parser):
-    parser.addoption("--wiki_domain", action="store")
-    parser.addoption("--wiki_username", action="store")
-    parser.addoption("--wiki_password", action="store")
-    parser.addoption("--db_username", action="store")
-    parser.addoption("--db_password", action="store")
+# Note: pytest_addoption lives in the repo-root conftest.py - since pytest 9.0
+# it is not loaded from this subdirectory conftest via testpaths. The
+# option-backed fixtures below stay here.
 
 
 @pytest.fixture(scope="session")


### PR DESCRIPTION
pytest 9.0 no longer loads pytest_addoption from tests/conftest.py when the path comes from testpaths, breaking --wiki_domain/--wiki_username/ --wiki_password ("unrecognized arguments"). Move pytest_addoption to a repo-root conftest.py (always loaded at startup) and drop the duplicate from tests/conftest.py; option-backed fixtures stay in tests/conftest.py