### PR TITLE
prevent KeyError when wiki file does not exist in download fallback

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -66,3 +66,5 @@ playground
 
 # Automatically added by osw.auth.CredentialManager.save_credentials_to_file:
 */osw_files/*
+
+*/accounts.pwd.yaml

--- a/src/osw/controller/file/wiki.py
+++ b/src/osw/controller/file/wiki.py
@@ -40,6 +40,7 @@ class WikiFileController(model.WikiFile, RemoteFileController):
         # use web api
         full_title = f"{self.namespace}:{self.title}"
         web_api_failed = False
+        file_not_found = False
         response = None
         try:
             url = (
@@ -54,7 +55,7 @@ class WikiFileController(model.WikiFile, RemoteFileController):
             if api_error is not None:
                 if api_error == "download-notfound":
                     # File does not exist
-                    raise Exception("File does not exist: " + full_title)
+                    file_not_found = True
                 elif api_error == "badvalue":
                     # Extension FileApi not installed on the server
                     web_api_failed = True
@@ -64,6 +65,8 @@ class WikiFileController(model.WikiFile, RemoteFileController):
 
         except Exception:
             web_api_failed = True
+        if file_not_found:
+            raise Exception("File does not exist: " + full_title)
         if web_api_failed:
             # fallback: use direct download
             url = file.imageinfo["url"]


### PR DESCRIPTION
When the MediaWiki FileApi returns download-notfound, the exception raised
inside the try block was silently caught by the broad `except Exception`,
setting web_api_failed=True. The subsequent fallback then crashed with
KeyError: 'url' because the file's imageinfo has no URL for non-existent
files. Fix by using a flag instead of raising inside the try block.