### PR TITLE
fix: prevent silent page loss in store_entity parallel upload

### DIFF
--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -1593,10 +1593,33 @@ class OSW(BaseModel):
         change_id: str
         """The ID of the change"""
         pages: Dict[str, WtPage]
-        """The pages that have been stored"""
+        """The pages that have been successfully stored, keyed by full page title.
+        On partial failure this contains only the successfully-stored pages."""
+        failed: Dict[str, Exception] = {}
+        """Entities that could not be stored, keyed by full page title and mapped to
+        the exception that caused the failure. Empty on full success."""
 
         class Config:
             arbitrary_types_allowed = True
+
+    class StoreEntityPartialError(Exception):
+        """Raised by store_entity() when one or more entities could not be stored.
+
+        Carries the partial ``StoreEntityResult`` so callers can learn exactly which
+        entities were written (``stored`` / ``result.pages``) and which failed
+        (``failed`` / ``result.failed``) without a separate existence query.
+        """
+
+        def __init__(self, result: "OSW.StoreEntityResult"):
+            self.result = result
+            self.stored = list(result.pages.keys())
+            self.failed = result.failed
+            total = len(result.pages) + len(result.failed)
+            failed_titles = ", ".join(result.failed.keys())
+            super().__init__(
+                f"store_entity failed for {len(result.failed)} of {total} "
+                f"entities: {failed_titles}"
+            )
 
     def store_entity(
         self, param: Union[StoreEntityParam, OswBaseModel, List[OswBaseModel]]
@@ -1790,27 +1813,63 @@ class OSW(BaseModel):
                 upload_index += 1
 
         def handle_upload_object_(upload_object: UploadObject) -> None:
+            # Let exceptions propagate: the caller collects them per entity below,
+            # so a single failure neither aborts the batch nor is silently
+            # swallowed (store_entity_ only records created_pages on success).
+            store_entity_(
+                upload_object.entity,
+                upload_object.namespace,
+                upload_object.index,
+                upload_object.overwrite_class_param,
+            )
+
+        def failure_title_(upload_object: UploadObject) -> str:
+            """Best-effort full page title of a failed entity, for error reporting."""
             try:
-                store_entity_(
-                    upload_object.entity,
-                    upload_object.namespace,
-                    upload_object.index,
-                    upload_object.overwrite_class_param,
+                namespace = upload_object.namespace or get_namespace(
+                    upload_object.entity
                 )
-            except Exception as e:
-                entity_name = getattr(upload_object.entity, "name", None) or "unknown"
-                _logger.error(f"Error storing entity '{entity_name}': {e}")
+                return f"{namespace}:{get_title(upload_object.entity)}"
+            except Exception:
+                return (
+                    getattr(upload_object.entity, "name", None)
+                    or getattr(upload_object.entity, "uuid", None)
+                    or "unknown"
+                )
 
         if param.parallel:
-            _ = parallelize(
-                handle_upload_object_, upload_object_list, flush_at_end=param.debug
+            # return_exceptions=True keeps results aligned with upload_object_list
+            # and lets every entity be attempted even if some fail.
+            results = parallelize(
+                handle_upload_object_,
+                upload_object_list,
+                flush_at_end=param.debug,
+                return_exceptions=True,
             )
         else:
-            _ = [
-                handle_upload_object_(upload_object)
-                for upload_object in upload_object_list
-            ]
-        return OSW.StoreEntityResult(change_id=param.change_id, pages=created_pages)
+            results = []
+            for upload_object in upload_object_list:
+                try:
+                    handle_upload_object_(upload_object)
+                    results.append(None)
+                except Exception as e:  # noqa: BLE001 - collected below
+                    results.append(e)
+
+        failed: Dict[str, Exception] = {}
+        for upload_object, result in zip(upload_object_list, results):
+            if isinstance(result, Exception):
+                title = failure_title_(upload_object)
+                _logger.error(f"Error storing entity '{title}': {result}")
+                failed[title] = result
+
+        store_result = OSW.StoreEntityResult(
+            change_id=param.change_id, pages=created_pages, failed=failed
+        )
+        if failed:
+            # Surface partial/total failure so callers cannot mistake a dropped
+            # page for a success. The result (successes + failures) rides along.
+            raise OSW.StoreEntityPartialError(store_result)
+        return store_result
 
     class DeleteEntityParam(OswBaseModel):
         entities: Union[OswBaseModel, List[OswBaseModel]]

--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -1610,7 +1610,7 @@ class OSW(BaseModel):
         (``failed`` / ``result.failed``) without a separate existence query.
         """
 
-        def __init__(self, result: "OSW.StoreEntityResult"):
+        def __init__(self, result: OSW.StoreEntityResult):
             self.result = result
             self.stored = list(result.pages.keys())
             self.failed = result.failed
@@ -1852,7 +1852,7 @@ class OSW(BaseModel):
                 try:
                     handle_upload_object_(upload_object)
                     results.append(None)
-                except Exception as e:  # noqa: BLE001 - collected below
+                except Exception as e:
                     results.append(e)
 
         failed: Dict[str, Exception] = {}

--- a/src/osw/utils/util.py
+++ b/src/osw/utils/util.py
@@ -274,6 +274,7 @@ def parallelize(
     iterable: Iterable,
     flush_at_end: bool = False,
     progress_bar: bool = True,
+    return_exceptions: bool = False,
     **kwargs,
 ):
     """A function to parallelize tasks with a progress bar and a message buffer.
@@ -289,6 +290,11 @@ def parallelize(
         execution.
     progress_bar:
         If True, a progress bar will be displayed.
+    return_exceptions:
+        If True, exceptions raised by ``func`` are returned in the result list at the
+        position of the corresponding item (instead of aborting the whole batch on the
+        first failure). Mirrors ``asyncio.gather(return_exceptions=...)``. Results stay
+        aligned with the input order, so callers can zip them back to ``iterable``.
     kwargs:
         Keyword arguments to be passed to the function.z
     """
@@ -324,6 +330,18 @@ def parallelize(
             print(
                 f"Performing parallel execution of {func.__name__} ({len(tasks)} tasks)."
             )
+            if return_exceptions:
+                # tqdm.gather() re-raises the first exception (it has no
+                # return_exceptions kwarg), which would abandon the remaining
+                # results. Capture each task's exception instead so the batch
+                # completes and results stay aligned with the input order.
+                async def _capture(task):
+                    try:
+                        return await task
+                    except Exception as exc:  # noqa: BLE001 - returned to caller
+                        return exc
+
+                tasks = [_capture(task) for task in tasks]
             res = await tqdm.gather(
                 *tasks
             )  # like asyncio.gather, but with a progress bar

--- a/src/osw/utils/util.py
+++ b/src/osw/utils/util.py
@@ -338,7 +338,7 @@ def parallelize(
                 async def _capture(task):
                     try:
                         return await task
-                    except Exception as exc:  # noqa: BLE001 - returned to caller
+                    except Exception as exc:
                         return exc
 
                 tasks = [_capture(task) for task in tasks]

--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -5,6 +5,7 @@ caching OpenSemanticLab specific features are located in osw.core.OSW
 import json
 import os
 import shutil
+import threading
 import urllib
 import warnings
 import xml.etree.ElementTree as et
@@ -88,6 +89,13 @@ class WtSite:
 
         """
 
+        # Serializes destructive mutations of the shared mwclient session
+        # (cookie jar / tokens). Parallel uploads share one requests.Session, so
+        # concurrent clears/re-logins would otherwise corrupt each other's state.
+        # RLock (not Lock) because the edit() retry path may call _relogin() while
+        # already holding this lock.
+        self._session_lock = threading.RLock()
+
         scheme = "https"
 
         # Store credentials for potential re-login on session timeout
@@ -153,6 +161,20 @@ class WtSite:
         self._page_cache = {}
         self._cache_enabled = False
 
+    def _get_session_lock(self) -> threading.RLock:
+        """Return the session lock, lazily creating it if absent.
+
+        In normal use the lock is created in ``__init__`` before any worker
+        threads exist. This fallback keeps WtSite instances that bypassed
+        ``__init__`` (e.g. tests using ``WtSite.__new__``) working; those are
+        single-threaded at construction, so the lazy creation is race-free.
+        """
+        lock = getattr(self, "_session_lock", None)
+        if lock is None:
+            lock = threading.RLock()
+            self._session_lock = lock
+        return lock
+
     def _relogin(self):
         """Re-login to the wiki site using stored credentials.
 
@@ -174,9 +196,12 @@ class WtSite:
             # Stale session cookies cause MediaWiki to abort the login flow with
             # "Unable to continue login. Your session most likely timed out."
             # Clear client-side session state so login starts from a clean slate.
-            self._site.connection.cookies.clear()
-            self._site.tokens.clear()
-            self._site.login(username=cred.username, password=cred.password)
+            # Hold the session lock so in-flight parallel uploads cannot read the
+            # cookie jar / tokens while they are being wiped and rebuilt.
+            with self._get_session_lock():
+                self._site.connection.cookies.clear()
+                self._site.tokens.clear()
+                self._site.login(username=cred.username, password=cred.password)
         else:
             raise RuntimeError(
                 "Re-login is only supported for username/password credentials."
@@ -457,11 +482,14 @@ class WtSite:
 
     def _clear_cookies(self):
         # see https://github.com/mwclient/mwclient/issues/221
-        for cookie in self._site.connection.cookies:
-            if "PostEditRevision" in cookie.name:
-                self._site.connection.cookies.clear(
-                    cookie.domain, cookie.path, cookie.name
-                )
+        # Iterate a snapshot (list(...)) so mutating the jar mid-loop is safe, and
+        # hold the session lock so a peer thread cannot clear/re-login concurrently.
+        with self._get_session_lock():
+            for cookie in list(self._site.connection.cookies):
+                if "PostEditRevision" in cookie.name:
+                    self._site.connection.cookies.clear(
+                        cookie.domain, cookie.path, cookie.name
+                    )
 
     class SearchParam(wt.SearchParam):
         pass
@@ -1718,26 +1746,42 @@ class WtPage:
         mode:
             (optional) single API call ('action-multislot') or multiple (
             'action-singleslot'), by default 'action-multislot' (faster)
+
+        Raises
+        ------
+        RuntimeError
+            if the edit still fails after ``max_retry`` attempts. The last
+            underlying exception is chained via ``__cause__``. Previously this
+            method returned None on exhaustion, silently discarding the failure.
         """
-        retry = 0
         max_retry = 5
-        while retry < max_retry:
+        last_exc: Optional[Exception] = None
+        for attempt in range(max_retry):
             try:
                 return self._edit(comment, mode, bot_edit)
-            except Exception as e:
-                if retry < max_retry:
-                    retry += 1
-                    print(f"Page edit failed: {e}. Retry ({retry}/{max_retry})")
+            except Exception as e:  # noqa: BLE001 - re-raised below after retries
+                last_exc = e
+                print(f"Page edit failed: {e}. Retry ({attempt + 1}/{max_retry})")
+                if attempt + 1 < max_retry:
+                    # Attempt to recover the shared session before retrying.
+                    # Guard the whole block: a recovery failure must never mask
+                    # the original edit error we intend to re-raise below.
                     try:
-                        # refresh token for longer running processes
-                        self.wtSite._site.get_token("csrf", force=True)
+                        # Serialize session mutations so a peer thread's request
+                        # cannot read a half-cleared cookie jar / token set.
+                        with self.wtSite._get_session_lock():
+                            try:
+                                # refresh token for longer running processes
+                                self.wtSite._site.get_token("csrf", force=True)
+                            except Exception:
+                                # token refresh failed, attempt full re-login
+                                self.wtSite._relogin()
                     except Exception:
-                        # token refresh failed, attempt full re-login
-                        try:
-                            self.wtSite._relogin()
-                        except Exception:
-                            pass  # re-login failed, will retry anyway
+                        pass  # recovery failed, will retry / re-raise anyway
                     sleep(5)
+        raise RuntimeError(
+            f"Page edit for '{self.title}' failed after {max_retry} attempts"
+        ) from last_exc
 
     def _edit(
         self, comment: str = None, mode="action-multislot", bot_edit: bool = True

--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -498,10 +498,21 @@ class WtSite:
         # hold the session lock so a peer thread cannot clear/re-login concurrently.
         with self._get_session_lock():
             for cookie in list(self._site.connection.cookies):
+                # The session lock does not cover requests' own jar writes:
+                # extract_cookies() drops any cookie whose Set-Cookie expiry is in
+                # the past, on every response. On py<=3.10 http.cookiejar iterates
+                # via a lazy map(dict.get, sorted(keys)), so such a delete makes the
+                # snapshot yield None instead of a cookie.
+                if cookie is None:
+                    continue
                 if "PostEditRevision" in cookie.name:
-                    self._site.connection.cookies.clear(
-                        cookie.domain, cookie.path, cookie.name
-                    )
+                    try:
+                        self._site.connection.cookies.clear(
+                            cookie.domain, cookie.path, cookie.name
+                        )
+                    except KeyError:
+                        # already removed between snapshot and delete
+                        pass
 
     class SearchParam(wt.SearchParam):
         pass

--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -175,6 +175,18 @@ class WtSite:
             self._session_lock = lock
         return lock
 
+    def __getstate__(self):
+        """Drop the session lock when copying or pickling.
+
+        A WtSite is deep-copied as a side effect of copying a WtPage, which
+        happens on every store_entity() call (OSW._apply_overwrite_policy).
+        threading.RLock cannot be copied, so exclude it here; the copy gets a
+        fresh lock from _get_session_lock() on first use.
+        """
+        state = self.__dict__.copy()
+        state.pop("_session_lock", None)
+        return state
+
     def _relogin(self):
         """Re-login to the wiki site using stored credentials.
 
@@ -1759,7 +1771,7 @@ class WtPage:
         for attempt in range(max_retry):
             try:
                 return self._edit(comment, mode, bot_edit)
-            except Exception as e:  # noqa: BLE001 - re-raised below after retries
+            except Exception as e:
                 last_exc = e
                 print(f"Page edit failed: {e}. Retry ({attempt + 1}/{max_retry})")
                 if attempt + 1 < max_retry:

--- a/tests/test_store_entity_failure.py
+++ b/tests/test_store_entity_failure.py
@@ -1,0 +1,99 @@
+"""Unit tests for store_entity() per-entity failure reporting (Fix C).
+
+These run fully offline: WtPage.init and the overwrite policy are stubbed so no
+network is required, and WtPage.edit is replaced with a controllable stub that
+fails for selected page titles.
+"""
+
+import pytest
+
+import osw.model.entity as model
+from osw.core import OSW
+from osw.utils.wiki import get_namespace, get_title
+from osw.wtsite import WtPage
+
+
+def _title(entity):
+    return f"{get_namespace(entity)}:{get_title(entity)}"
+
+
+@pytest.fixture
+def offline_osw(monkeypatch):
+    # no network when a WtPage is constructed with do_init=True; mimic the
+    # do_init=False branch of WtPage.__init__ which sets .exists
+    monkeypatch.setattr(WtPage, "init", lambda self: setattr(self, "exists", False))
+    # bypass the overwrite policy: return the page that was built for the entity
+    monkeypatch.setattr(
+        OSW, "_apply_overwrite_policy", staticmethod(lambda param: param.page)
+    )
+    return OSW.construct(site=object())
+
+
+def _install_edit(monkeypatch, failing_titles):
+    def fake_edit(self, *args, **kwargs):
+        if self.title in failing_titles:
+            raise RuntimeError(f"edit failed for {self.title}")
+        return None
+
+    monkeypatch.setattr(WtPage, "edit", fake_edit)
+
+
+def test_store_entity_serial_single_failure_raises(offline_osw, monkeypatch):
+    item = model.Item(label=[model.Label(text="Solo")])
+    title = _title(item)
+    _install_edit(monkeypatch, {title})
+
+    with pytest.raises(OSW.StoreEntityPartialError) as exc_info:
+        offline_osw.store_entity(OSW.StoreEntityParam(entities=[item], parallel=False))
+
+    err = exc_info.value
+    assert title in err.failed
+    assert isinstance(err.failed[title], RuntimeError)
+    # the dropped page must NOT be reported as stored
+    assert title not in err.result.pages
+    assert err.stored == []
+
+
+def test_store_entity_parallel_middle_failure_reports_all(offline_osw, monkeypatch):
+    items = [model.Item(label=[model.Label(text=f"Item{i}")]) for i in range(3)]
+    titles = [_title(it) for it in items]
+    failing = titles[1]
+    _install_edit(monkeypatch, {failing})
+
+    with pytest.raises(OSW.StoreEntityPartialError) as exc_info:
+        offline_osw.store_entity(OSW.StoreEntityParam(entities=items, parallel=True))
+
+    err = exc_info.value
+    # the two good entities are recorded as stored (the first exception did not
+    # abandon the remaining tasks) ...
+    assert set(err.result.pages.keys()) == {titles[0], titles[2]}
+    assert set(err.stored) == {titles[0], titles[2]}
+    # ... and the failing one is reported instead of being silently dropped
+    assert set(err.failed.keys()) == {failing}
+    assert isinstance(err.failed[failing], RuntimeError)
+
+
+def test_store_entity_all_success_returns_result(offline_osw, monkeypatch):
+    items = [model.Item(label=[model.Label(text=f"Ok{i}")]) for i in range(3)]
+    titles = [_title(it) for it in items]
+    _install_edit(monkeypatch, set())  # nothing fails
+
+    result = offline_osw.store_entity(
+        OSW.StoreEntityParam(entities=items, parallel=True)
+    )
+
+    assert set(result.pages.keys()) == set(titles)
+    assert result.failed == {}
+
+
+def test_store_entity_serial_all_success_returns_result(offline_osw, monkeypatch):
+    items = [model.Item(label=[model.Label(text=f"Ser{i}")]) for i in range(2)]
+    titles = [_title(it) for it in items]
+    _install_edit(monkeypatch, set())
+
+    result = offline_osw.store_entity(
+        OSW.StoreEntityParam(entities=items, parallel=False)
+    )
+
+    assert set(result.pages.keys()) == set(titles)
+    assert result.failed == {}

--- a/tests/test_wtsite_edit.py
+++ b/tests/test_wtsite_edit.py
@@ -1,0 +1,83 @@
+"""Unit tests for WtPage.edit() retry/re-raise behavior (Fix A).
+
+Regression guard: previously edit() returned None after exhausting its retries,
+silently discarding the last exception. It must now raise so callers (and
+store_entity) can see the failure.
+"""
+
+import threading
+
+import pytest
+
+import osw.wtsite as wtsite_mod
+from osw.wtsite import WtPage, WtSite
+
+
+class _FakeSite:
+    def get_token(self, *args, **kwargs):
+        raise RuntimeError("token refresh failed")
+
+
+def _make_fake_wtsite():
+    """A WtSite whose recovery hooks all fail, bypassing __init__ (no network)."""
+    ws = WtSite.__new__(WtSite)
+    ws._session_lock = threading.RLock()
+    ws._site = _FakeSite()
+
+    def _relogin_fails():
+        raise RuntimeError("relogin failed")
+
+    ws._relogin = _relogin_fails
+    return ws
+
+
+def test_edit_reraises_after_max_retries(monkeypatch):
+    monkeypatch.setattr(wtsite_mod, "sleep", lambda *a, **k: None)
+
+    ws = _make_fake_wtsite()
+    page = WtPage(wtSite=ws, title="Item:OSW123", do_init=False)
+
+    original_error = ValueError("edit boom")
+    attempts = {"n": 0}
+
+    def always_raise(*args, **kwargs):
+        attempts["n"] += 1
+        raise original_error
+
+    monkeypatch.setattr(page, "_edit", always_raise)
+
+    with pytest.raises(RuntimeError) as exc_info:
+        page.edit()
+
+    assert attempts["n"] == 5  # all max_retry attempts were made
+    # the original exception must be chained, not discarded
+    assert exc_info.value.__cause__ is original_error
+    assert "Item:OSW123" in str(exc_info.value)
+
+
+def test_edit_returns_result_on_success(monkeypatch):
+    monkeypatch.setattr(wtsite_mod, "sleep", lambda *a, **k: None)
+    ws = _make_fake_wtsite()
+    page = WtPage(wtSite=ws, title="Item:OSW123", do_init=False)
+    monkeypatch.setattr(page, "_edit", lambda *a, **k: "ok")
+
+    assert page.edit() == "ok"
+
+
+def test_edit_succeeds_after_transient_failures(monkeypatch):
+    monkeypatch.setattr(wtsite_mod, "sleep", lambda *a, **k: None)
+    ws = _make_fake_wtsite()
+    page = WtPage(wtSite=ws, title="Item:OSW123", do_init=False)
+
+    calls = {"n": 0}
+
+    def flaky(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] < 3:
+            raise RuntimeError("transient")
+        return "done"
+
+    monkeypatch.setattr(page, "_edit", flaky)
+
+    assert page.edit() == "done"
+    assert calls["n"] == 3

--- a/tests/test_wtsite_session_lock.py
+++ b/tests/test_wtsite_session_lock.py
@@ -1,0 +1,88 @@
+"""Unit tests for WtSite session-state concurrency hardening (Fix B1).
+
+These tests construct a WtSite without going through ``__init__`` (which would
+require network / credentials) and exercise ``_clear_cookies`` directly against a
+real ``requests`` cookie jar.
+"""
+
+import threading
+import types
+
+import requests.cookies as rc
+
+from osw.wtsite import WtSite
+
+
+def _make_wtsite_with_jar():
+    """Build a minimal WtSite carrying a real cookie jar, bypassing __init__."""
+    jar = rc.RequestsCookieJar()
+    fake_site = types.SimpleNamespace(connection=types.SimpleNamespace(cookies=jar))
+    ws = WtSite.__new__(WtSite)
+    ws._session_lock = threading.RLock()
+    ws._site = fake_site
+    return ws, jar
+
+
+def _populate(jar, n=25):
+    for i in range(n):
+        jar.set(f"PostEditRevision{i}", f"v{i}", domain="example.org", path="/")
+    # a cookie that must never be removed by _clear_cookies
+    jar.set("sessionToken", "keep-me", domain="example.org", path="/")
+
+
+def test_clear_cookies_removes_only_post_edit_revision():
+    ws, jar = _make_wtsite_with_jar()
+    _populate(jar)
+
+    ws._clear_cookies()
+
+    assert {c.name for c in jar} == {"sessionToken"}
+
+
+def test_clear_cookies_under_concurrency_is_safe():
+    """Concurrent clears + reads must not raise and must preserve unrelated cookies."""
+    ws, jar = _make_wtsite_with_jar()
+    _populate(jar)
+
+    errors = []
+    stop = threading.Event()
+
+    def clearer():
+        try:
+            for _ in range(200):
+                # re-add under the lock so there is always something to clear,
+                # creating real contention with the concurrent _clear_cookies calls
+                with ws._session_lock:
+                    for i in range(25):
+                        jar.set(
+                            f"PostEditRevision{i}",
+                            f"v{i}",
+                            domain="example.org",
+                            path="/",
+                        )
+                ws._clear_cookies()
+        except Exception as exc:  # noqa: BLE001 - collected and asserted below
+            errors.append(exc)
+
+    def reader():
+        try:
+            while not stop.is_set():
+                _ = [c.name for c in list(jar)]
+        except Exception as exc:  # noqa: BLE001 - collected and asserted below
+            errors.append(exc)
+
+    clearers = [threading.Thread(target=clearer) for _ in range(4)]
+    readers = [threading.Thread(target=reader) for _ in range(2)]
+    for t in readers:
+        t.start()
+    for t in clearers:
+        t.start()
+    for t in clearers:
+        t.join()
+    stop.set()
+    for t in readers:
+        t.join()
+
+    assert errors == []
+    # the non-PostEditRevision cookie must survive every clear
+    assert "sessionToken" in {c.name for c in jar}

--- a/tests/test_wtsite_session_lock.py
+++ b/tests/test_wtsite_session_lock.py
@@ -14,14 +14,19 @@ import requests.cookies as rc
 from osw.wtsite import WtPage, WtSite
 
 
-def _make_wtsite_with_jar():
-    """Build a minimal WtSite carrying a real cookie jar, bypassing __init__."""
-    jar = rc.RequestsCookieJar()
+def _make_wtsite_for(jar):
+    """Wrap an arbitrary cookie jar in a minimal WtSite, bypassing __init__."""
     fake_site = types.SimpleNamespace(connection=types.SimpleNamespace(cookies=jar))
     ws = WtSite.__new__(WtSite)
     ws._session_lock = threading.RLock()
     ws._site = fake_site
-    return ws, jar
+    return ws
+
+
+def _make_wtsite_with_jar():
+    """Build a minimal WtSite carrying a real cookie jar, bypassing __init__."""
+    jar = rc.RequestsCookieJar()
+    return _make_wtsite_for(jar), jar
 
 
 def _populate(jar, n=25):
@@ -40,51 +45,123 @@ def test_clear_cookies_removes_only_post_edit_revision():
     assert {c.name for c in jar} == {"sessionToken"}
 
 
+def _fake_cookie(name):
+    return types.SimpleNamespace(name=name, domain="example.org", path="/")
+
+
+class _FakeJar:
+    """Stands in for a jar being mutated by requests while we iterate it."""
+
+    def __init__(self, entries):
+        self._entries = entries
+        self.cleared = []
+
+    def __iter__(self):
+        return iter(self._entries)
+
+    def clear(self, domain, path, name):
+        self.cleared.append((domain, path, name))
+
+
+def test_clear_cookies_skips_none_entries_from_the_jar():
+    """py<=3.10 http.cookiejar yields None for a cookie deleted mid-iteration.
+
+    Its deepvalues() walks a lazy map(dict.get, sorted(keys)), so a concurrent
+    delete turns into a None rather than a missing entry. Without the guard this
+    raises AttributeError: 'NoneType' object has no attribute 'name'.
+    """
+    jar = _FakeJar([None, _fake_cookie("PostEditRevision1"), None])
+    ws = _make_wtsite_for(jar)
+
+    ws._clear_cookies()
+
+    assert jar.cleared == [("example.org", "/", "PostEditRevision1")]
+
+
+def test_clear_cookies_tolerates_a_cookie_already_removed():
+    """CookieJar.clear raises KeyError if a peer deleted the cookie first.
+
+    _clear_cookies works off a snapshot, so any entry may be gone by the time it
+    calls clear(). It must swallow that and keep going, not abort the sweep.
+    """
+
+    class _RacingJar(_FakeJar):
+        def clear(self, domain, path, name):
+            super().clear(domain, path, name)
+            raise KeyError(name)
+
+    jar = _RacingJar([
+        _fake_cookie("PostEditRevision1"),
+        _fake_cookie("PostEditRevision2"),
+    ])
+    ws = _make_wtsite_for(jar)
+
+    ws._clear_cookies()
+
+    # the KeyError on the first cookie must not stop the second from being tried
+    assert len(jar.cleared) == 2
+
+
 def test_clear_cookies_under_concurrency_is_safe():
-    """Concurrent clears + reads must not raise and must preserve unrelated cookies."""
+    """_clear_cookies must survive jar writes the session lock does not cover.
+
+    requests' own extract_cookies() runs on every response and drops any cookie
+    whose Set-Cookie expiry is in the past, taking only the jar's internal lock.
+    So it races _clear_cookies two ways: the delete can land between the
+    snapshot and the follow-up clear() (KeyError, any version), and on py<=3.10
+    http.cookiejar iterates via a lazy map(dict.get, sorted(keys)), so the
+    snapshot yields None instead of the deleted cookie.
+
+    Only _clear_cookies is asserted on. Unsynchronized iteration of the jar is
+    not something WtSite can make safe, since requests never takes the session
+    lock, so the reader here is a contention generator and nothing more.
+    """
     ws, jar = _make_wtsite_with_jar()
     _populate(jar)
 
-    errors = []
+    clear_errors = []
     stop = threading.Event()
+
+    def peer_writer():
+        """Stand in for requests.extract_cookies: set + delete, no session lock."""
+        while not stop.is_set():
+            for i in range(25):
+                jar.set(f"PostEditRevision{i}", f"v{i}", domain="example.org", path="/")
+            for i in range(25):
+                try:
+                    jar.clear("example.org", "/", f"PostEditRevision{i}")
+                except KeyError:
+                    pass
 
     def clearer():
         try:
             for _ in range(200):
-                # re-add under the lock so there is always something to clear,
-                # creating real contention with the concurrent _clear_cookies calls
-                with ws._session_lock:
-                    for i in range(25):
-                        jar.set(
-                            f"PostEditRevision{i}",
-                            f"v{i}",
-                            domain="example.org",
-                            path="/",
-                        )
                 ws._clear_cookies()
         except Exception as exc:
-            errors.append(exc)
+            clear_errors.append(exc)
 
     def reader():
-        try:
-            while not stop.is_set():
-                _ = [c.name for c in list(jar)]
-        except Exception as exc:
-            errors.append(exc)
+        while not stop.is_set():
+            try:
+                _ = [c.name for c in list(jar) if c is not None]
+            except RuntimeError:
+                # dict resized mid-iteration; the stdlib jar is not thread-safe
+                pass
 
+    peers = [threading.Thread(target=peer_writer, daemon=True) for _ in range(2)]
+    readers = [threading.Thread(target=reader, daemon=True) for _ in range(2)]
     clearers = [threading.Thread(target=clearer) for _ in range(4)]
-    readers = [threading.Thread(target=reader) for _ in range(2)]
-    for t in readers:
+    for t in peers + readers:
         t.start()
     for t in clearers:
         t.start()
     for t in clearers:
         t.join()
     stop.set()
-    for t in readers:
+    for t in peers + readers:
         t.join()
 
-    assert errors == []
+    assert clear_errors == []
     # the non-PostEditRevision cookie must survive every clear
     assert "sessionToken" in {c.name for c in jar}
 

--- a/tests/test_wtsite_session_lock.py
+++ b/tests/test_wtsite_session_lock.py
@@ -7,10 +7,11 @@ real ``requests`` cookie jar.
 
 import threading
 import types
+from copy import deepcopy
 
 import requests.cookies as rc
 
-from osw.wtsite import WtSite
+from osw.wtsite import WtPage, WtSite
 
 
 def _make_wtsite_with_jar():
@@ -61,14 +62,14 @@ def test_clear_cookies_under_concurrency_is_safe():
                             path="/",
                         )
                 ws._clear_cookies()
-        except Exception as exc:  # noqa: BLE001 - collected and asserted below
+        except Exception as exc:
             errors.append(exc)
 
     def reader():
         try:
             while not stop.is_set():
                 _ = [c.name for c in list(jar)]
-        except Exception as exc:  # noqa: BLE001 - collected and asserted below
+        except Exception as exc:
             errors.append(exc)
 
     clearers = [threading.Thread(target=clearer) for _ in range(4)]
@@ -86,3 +87,24 @@ def test_clear_cookies_under_concurrency_is_safe():
     assert errors == []
     # the non-PostEditRevision cookie must survive every clear
     assert "sessionToken" in {c.name for c in jar}
+
+
+def test_wtsite_survives_deepcopy_of_a_page():
+    """store_entity deep-copies the page, reaching WtSite through page.wtSite.
+
+    Without WtSite.__getstate__ dropping the lock this raises
+    TypeError: cannot pickle '_thread.RLock' object.
+    """
+    ws, jar = _make_wtsite_with_jar()
+    _populate(jar)
+    page = WtPage.__new__(WtPage)
+    page.wtSite = ws
+    page._slots = {"jsondata": {"uuid": "abc"}}
+
+    copied = deepcopy(page)
+
+    assert copied._slots == page._slots
+    assert copied._slots is not page._slots
+    # the copy has no lock until something asks for one
+    assert "_session_lock" not in copied.wtSite.__dict__
+    assert copied.wtSite._get_session_lock() is not ws._session_lock


### PR DESCRIPTION
## Summary

`store_entity(..., parallel=True)` could silently drop one or more pages during a
batch upload while still reporting the batch as fully successful. Three linked
defects combined to cause this; this PR fixes all three and adds offline unit tests
for each.

## What went wrong

Each entity in a parallel batch is uploaded on its own worker thread, but every
thread shares one mwclient session (a single cookie jar and CSRF-token cache). Three
problems interacted:

1. **Unserialized session resets.** On a transient edit failure, the recovery path
   refreshes the CSRF token and, if that fails, runs a full re-login: clear cookies,
   clear tokens, log in again. That is a multi-step, non-atomic wipe-and-rebuild of
   shared auth state. When two threads hit a failure at the same time, their reset
   sequences interleave and leave the session in a corrupt intermediate state (for
   example, cookies cleared by one thread while another is mid-login). A subsequent
   request from a third thread then goes out with missing or invalid auth and its
   edit fails.

2. **Mutation during iteration.** `_clear_cookies()` looped over the live cookie jar
   while calling `.clear(...)` inside the loop, so it could skip cookies or raise
   while mutating the collection it was iterating.

3. **Silently swallowed failure.** After exhausting its retries, `WtPage.edit()`
   returned `None` instead of raising. `store_entity` treated that non-exception
   result as success and dropped the entity from the batch result, so a page that
   never got written was reported as stored. This is what turned the races above
   into *silent* data loss.

## The fixes

### Fix A - `WtPage.edit()` raises on exhaustion (wtsite.py)

The retry loop now records the last exception and, once all attempts are used up,
raises `RuntimeError(...) from last_exc` instead of returning `None`. A page that
genuinely cannot be written now surfaces as an error instead of vanishing.

### Fix B1 - serialize destructive session mutations (wtsite.py)

A per-`WtSite` reentrant lock (`self._session_lock`) now guards the three operations
that destructively mutate the shared session:

- `_relogin()`
- `_clear_cookies()`
- the token-refresh / re-login recovery block inside `edit()`

Because all three acquire the same lock, two threads can never be inside a
clear/re-login sequence simultaneously, so the wipe-and-rebuild is effectively atomic
with respect to any other thread that also wants to reset the session. This removes
the writer-writer race and the double-re-login corruption. The lock is reentrant
because `edit()`'s recovery block holds it and then calls `_relogin()`, which acquires
it again on the same thread; a non-reentrant lock would self-deadlock there.
`_clear_cookies()` also now iterates a `list(...)` snapshot of the jar, fixing the
mutation-during-iteration bug. A lazy `_get_session_lock()` accessor keeps instances
constructed via `WtSite.__new__` (used in tests) working; those are single-threaded at
construction, so on-demand creation is race-free.

### Fix C - surface per-entity outcomes (util.py, core.py)

- `parallelize()` gains a `return_exceptions` flag (mirroring `asyncio.gather`): a
  failing task's exception is captured in place instead of aborting the whole batch
  and discarding the other results, and results stay aligned with input order.
- `store_entity` now collects per-entity outcomes for both the serial and parallel
  paths, records failures in the new `StoreEntityResult.failed`, and raises
  `OSW.StoreEntityPartialError` carrying the partial result (which pages were stored
  and which failed). Callers learn exactly what happened without a separate existence
  query.

## Caveat / scope of the lock

The lock serializes the destructive mutations against **each other**; it does **not**
wrap the normal request path. `edit()`'s actual API call reads cookies/tokens without
taking the lock. This is deliberate: locking every request would serialize all
uploads and defeat parallelism. Because clears and re-logins only happen on the rare
failure/timeout recovery path, guarding just those removes the damaging races while
keeping the common upload path fully parallel. In other words, this narrows the
"a normal request reads a half-cleared jar" window rather than eliminating it
absolutely.

## Tests

Offline unit tests (no network) covering each fix:

- `tests/test_wtsite_edit.py` - edit re-raises after max retries, returns result on
  success, recovers after transient failures.
- `tests/test_wtsite_session_lock.py` - `_clear_cookies` removes only the intended
  revision cookie and is safe under concurrency.
- `tests/test_store_entity_failure.py` - partial-failure reporting via
  `StoreEntityResult.failed` / `OSW.StoreEntityPartialError`.
