### PR TITLE
fix(deps): widen workflow anyio pin to >=4.9,<4.14

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -73,10 +73,12 @@ workflow = [
     "prefect>=2.20.25,<3.0",
     # prefect 2.20.25 is the final 2.x release (no backports). Its
     # GatherTaskGroup subclasses anyio's TaskGroup but doesn't implement
-    # create_task, which newer anyio 4.x made abstract (broken on 4.14,
-    # verified good on 4.6.2); hold anyio to the last verified-good 4.6 line
-    # so the prefect-2.x flow engine can still instantiate task groups.
-    "anyio>=4.4.0,<4.7",
+    # create_task, which anyio 4.14.0 promoted to an abstract method
+    # (start_soon stopped being the abstract one). 4.13.x is the last line
+    # where the prefect-2.x flow engine can still instantiate task groups.
+    # The floor is 4.9 so this stays compatible with mcp>=2, see
+    # https://github.com/OpenSemanticLab/osw-python/issues/139
+    "anyio>=4.9,<4.14",
 ]
 tutorial = ["osw[dataimport]"]
 all = ["osw[dataimport,DB,UI,S3,wikitext]"]

--- a/uv.lock
+++ b/uv.lock
@@ -46,17 +46,16 @@ wheels = [
 
 [[package]]
 name = "anyio"
-version = "4.6.2.post1"
+version = "4.13.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "exceptiongroup", marker = "python_full_version < '3.11'" },
     { name = "idna" },
-    { name = "sniffio" },
-    { name = "typing-extensions", marker = "python_full_version < '3.11'" },
+    { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9f/09/45b9b7a6d4e45c6bcb5bf61d19e3ab87df68e0601fa8c5293de3542546cc/anyio-4.6.2.post1.tar.gz", hash = "sha256:4c8bc31ccdb51c7f7bd251f51c609e038d63e34219b44aa86e47576389880b4c", size = 173422, upload-time = "2024-10-14T14:31:44.021Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/19/14/2c5dd9f512b66549ae92767a9c7b330ae88e1932ca57876909410251fe13/anyio-4.13.0.tar.gz", hash = "sha256:334b70e641fd2221c1505b3890c69882fe4a2df910cba14d97019b90b24439dc", size = 231622, upload-time = "2026-03-24T12:59:09.671Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/f5/f2b75d2fc6f1a260f340f0e7c6a060f4dd2961cc16884ed851b0d18da06a/anyio-4.6.2.post1-py3-none-any.whl", hash = "sha256:6d170c36fba3bdd840c73d3868c1e777e33676a69c3a72cf0a0d5d6d8009b61d", size = 90377, upload-time = "2024-10-14T14:31:42.623Z" },
+    { url = "https://files.pythonhosted.org/packages/da/42/e921fccf5015463e32a3cf6ee7f980a6ed0f395ceeaa45060b61d86486c2/anyio-4.13.0-py3-none-any.whl", hash = "sha256:08b310f9e24a9594186fd75b4f73f4a4152069e3853f1ed8bfbf58369f4ad708", size = 114353, upload-time = "2026-03-24T12:59:08.246Z" },
 ]
 
 [[package]]
@@ -2073,7 +2072,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "anyio", marker = "extra == 'workflow'", specifier = ">=4.4.0,<4.7" },
+    { name = "anyio", marker = "extra == 'workflow'", specifier = ">=4.9,<4.14" },
     { name = "backports-strenum", marker = "python_full_version < '3.11'" },
     { name = "black" },
     { name = "boto3", marker = "extra == 's3'" },


### PR DESCRIPTION
Widens the `workflow` extra's anyio constraint from `>=4.4.0,<4.7` to `>=4.9,<4.14`.

Closes https://github.com/OpenSemanticLab/osw-python/issues/139

## Changes

- `pyproject.toml`: `workflow` extra now pins `anyio>=4.9,<4.14`; the explanatory comment records the actual break point instead of the previous conservative guess
- `uv.lock`: `anyio 4.6.2.post1 -> 4.13.0`; `prefect` stays at `2.20.25`

## Rationale

The old `<4.7` cap was seven minor releases tighter than necessary. Bisecting `prefect==2.20.25` against every anyio minor (py3.12, exercising prefect's own `gather()`):

| anyio | `GatherTaskGroup.__abstractmethods__` | result |
|---|---|---|
| 4.6.2, 4.7.0, 4.9.0, 4.10.0, 4.11.0, 4.12.0, 4.13.0 | `[]` | works |
| 4.14.0, 4.14.2 (latest) | `['create_task']` | `TypeError: Can't instantiate abstract class GatherTaskGroup` |

anyio 4.14.0 added `create_task()` to the `TaskGroup` ABC and changed `start_soon()` to return a `TaskHandle` ([agronholm/anyio#1098](https://github.com/agronholm/anyio/issues/1098)). That promoted `create_task` into the abstract set, breaking prefect's external subclass. Not reverted in 4.14.1 or 4.14.2, and prefect 2.20.25 is the final 2.x release, so no backport is coming - hence the cap stays, just at the correct value.

The `>=4.9` floor is what matters for https://github.com/OpenSemanticLab/osw-python/issues/139: `mcp 2.1.1` requires `anyio>=4.9` (its stricter `>=4.10` clause is gated on `python_version >= '3.14'`, and this project is `requires-python = ">=3.10,<3.14"`, so it never applies). `>=4.9,<4.14` therefore satisfies the `workflow` and `mcp` extras simultaneously:

```
prefect 2.20.25 + mcp 2.1.1 + anyio 4.13.0  ->  both import, GatherTaskGroup concrete
```

No prefect 3.x migration and no source changes are needed.

## Verification

- `uv lock` and `uv sync` succeed
- full default suite: 36 passed, 1 skipped
- workflow tests pass: `test_notify_teams`, `test_tags_str_to_list`, `test_deploy_serve`. `test_deploy_runner` is skipped by a pre-existing unconditional `"Not deployable in test environment"` marker

## Follow-up

Not in this PR, since these live on `feat/mcp-server`. Once this lands, five of the six workarounds from https://github.com/OpenSemanticLab/osw-python/pull/133 can be reverted:

1. `[tool.uv] conflicts` (mcp vs workflow, mcp vs dev)
2. `mcp` excluded from the `all` extra
3. `dev` listing `prefect`/`anyio` directly instead of `osw[workflow]`, which requires keeping two copies of the pins in sync by hand
4. the separate `test` group, split out only because `dev` conflicted with the `mcp` extra
5. the `importorskip` guards in the MCP tests

The sixth (`ty` exclude for `src/osw/mcp`) is already undone on that branch. Reverting these puts the MCP module back under type checking and unit testing in the default `uv sync` environment.
