### PR TITLE
fix: handle empty SMW ask results in semantic_search

### DIFF
--- a/src/osw/wiki_tools.py
+++ b/src/osw/wiki_tools.py
@@ -1,4 +1,5 @@
 import getpass
+import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import mwclient
@@ -216,6 +217,33 @@ def prefix_search(
     #  return page_list  # original return
 
 
+def _ask_results_as_dict(results: Union[dict, list]) -> dict:
+    """Normalise the ``results`` payload of an SMW ``ask`` response to a mapping.
+
+    SMW serialises a non-empty result set as a JSON object keyed by page title,
+    but an empty one as a JSON array, which would otherwise break attribute
+    access on the result.
+
+    Parameters
+    ----------
+    results :
+        The ``result["query"]["results"]`` payload of an SMW ``ask`` response.
+
+    Returns
+    -------
+    result:
+        The payload normalised to a dict, keyed by page title (or index if a
+        title is unavailable).
+    """
+    if isinstance(results, dict):
+        return results
+    if not results:
+        return {}
+    return {
+        page.get("fulltext", str(index)): page for index, page in enumerate(results)
+    }
+
+
 def semantic_search(
     site: mwclient.client.Site, query: Union[str, List[str], SearchParam]
 ) -> Union[List[str], List[dict]]:
@@ -242,19 +270,25 @@ def semantic_search(
         page_list = list()
         single_query += f"|limit={query.limit}"
         result = site.api("ask", query=single_query, format="json")
+        results = _ask_results_as_dict(result["query"]["results"])
+        n = len(results)
         if query.debug:
-            if len(result["query"]["results"]) == 0:
+            if n == 0:
                 print(f"Query '{single_query}' returned no results")
             else:
-                print(
-                    "Query '{}' returned {} results".format(
-                        single_query, len(result["query"]["results"])
-                    )
-                )
+                print(f"Query '{single_query}' returned {n} results")
+        if n >= query.limit:
+            warnings.warn(
+                f"Query '{single_query}' returned {n} results, which meets the "
+                f"requested limit of {query.limit}. Results are truncated - raise "
+                f"the limit or page through with '|offset=' to retrieve the "
+                f"remainder."
+            )
         if query.return_json:
             return result
 
-        for page in result["query"]["results"].values():
+        dropped = 0
+        for page in results.values():
             title = page["fulltext"]
             exists = page["exists"]
             if "#" not in title and query.debug:
@@ -262,6 +296,13 @@ def semantic_search(
                 # original position of "page_list.append(title)" line
             if exists == "1":
                 page_list.append(title)
+            else:
+                dropped += 1
+        if dropped > 0:
+            warnings.warn(
+                f"Query '{single_query}': {dropped} of {n} results were dropped "
+                f"because the wiki reported them as non-existing pages."
+            )
         return page_list
 
     if query.parallel:

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -1,4 +1,7 @@
+import warnings
 from unittest.mock import MagicMock
+
+import pytest
 
 import osw.wiki_tools as wt
 
@@ -27,6 +30,12 @@ def _ask_result(*titles):
             }
         }
     }
+
+
+def _ask_result_empty():
+    """Build the SMW ``ask`` API result dict for a zero-result query, mirroring
+    SMW's behaviour of serialising an empty result set as a JSON array."""
+    return {"query": {"results": []}}
 
 
 def test_semantic_search_return_json_single_query_returns_list_with_dict():
@@ -76,6 +85,126 @@ def test_semantic_search_returns_flat_list_of_titles():
 
     # return_json=False (the default) still yields a flat list of page titles
     assert out == ["Item:OSW1", "Item:OSW2"]
+
+
+def test_semantic_search_zero_results_returns_empty_list():
+    site = MagicMock()
+    site.api.return_value = _ask_result_empty()
+
+    out = wt.semantic_search(site, "[[HasType::Category:Nonexistent]]")
+
+    assert out == []
+
+
+def test_semantic_search_zero_results_return_json_returns_list_with_dict():
+    result = _ask_result_empty()
+    site = MagicMock()
+    site.api.return_value = result
+
+    out = wt.semantic_search(
+        site,
+        wt.SearchParam(query="[[HasType::Category:Nonexistent]]", return_json=True),
+    )
+
+    assert out == [result]
+
+
+def test_semantic_search_batch_with_one_zero_result_query():
+    result_a = _ask_result("Item:OSW1")
+    result_b = _ask_result_empty()
+    result_c = _ask_result("Item:OSW3")
+    site = MagicMock()
+    site.api.side_effect = [result_a, result_b, result_c]
+
+    out = wt.semantic_search(
+        site,
+        wt.SearchParam(
+            query=[
+                "[[HasType::Category:A]]",
+                "[[HasType::Category:B]]",
+                "[[HasType::Category:C]]",
+            ]
+        ),
+    )
+
+    assert out == ["Item:OSW1", "Item:OSW3"]
+
+
+def test_semantic_search_parallel_batch_with_one_zero_result_query():
+    results = [
+        _ask_result("Item:OSW1"),
+        _ask_result("Item:OSW2"),
+        _ask_result_empty(),
+        _ask_result("Item:OSW4"),
+        _ask_result("Item:OSW5"),
+        _ask_result("Item:OSW6"),
+    ]
+    site = MagicMock()
+    site.api.side_effect = results
+
+    out = wt.semantic_search(
+        site,
+        wt.SearchParam(
+            query=[
+                "[[HasType::Category:A]]",
+                "[[HasType::Category:B]]",
+                "[[HasType::Category:C]]",
+                "[[HasType::Category:D]]",
+                "[[HasType::Category:E]]",
+                "[[HasType::Category:F]]",
+            ]
+        ),
+    )
+
+    assert sorted(out) == [
+        "Item:OSW1",
+        "Item:OSW2",
+        "Item:OSW4",
+        "Item:OSW5",
+        "Item:OSW6",
+    ]
+
+
+def test_semantic_search_truncation_warning():
+    titles = [f"Item:OSW{i}" for i in range(5)]
+    result = _ask_result(*titles)
+    site = MagicMock()
+    site.api.return_value = result
+
+    with pytest.warns(UserWarning, match="truncated"):
+        out = wt.semantic_search(
+            site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=5)
+        )
+
+    assert sorted(out) == sorted(titles)
+
+
+def test_semantic_search_no_truncation_warning_below_limit():
+    titles = [f"Item:OSW{i}" for i in range(5)]
+    result = _ask_result(*titles)
+    site = MagicMock()
+    site.api.return_value = result
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        out = wt.semantic_search(
+            site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=1000)
+        )
+
+    assert not any("truncated" in str(w.message) for w in caught)
+    assert sorted(out) == sorted(titles)
+
+
+def test_semantic_search_exists_drop_warning():
+    result = _ask_result("Item:OSW1", "Item:OSW2")
+    result["query"]["results"]["Item:OSW2"]["exists"] = ""
+    site = MagicMock()
+    site.api.return_value = result
+
+    with pytest.warns(UserWarning, match="non-existing"):
+        out = wt.semantic_search(site, "[[HasType::Category:Item]]")
+
+    assert out == ["Item:OSW1"]
 
 
 def _prefixsearch_result(*titles):


### PR DESCRIPTION
Fixes the crash behind https://github.com/OpenSemanticLab/osw-python/issues/145 and explains the "random results" in https://github.com/OpenSemanticLab/osw-python/issues/111.

## Root causes

Three separate defects, all reproduced live against `healthbatt.projects01.open-semantic-lab.org`.

**1. Zero-result queries raise `AttributeError` (fixed here)**

SMW's `action=ask` serialises a non-empty result set as a JSON object keyed by page title, but an empty one as a JSON array. `semantic_search` called `.values()` on it unconditionally (`src/osw/wiki_tools.py:257`), so every zero-result query raised `AttributeError: 'list' object has no attribute 'values'` instead of returning `[]`.

```
[[HasUuid::b5cbec50-fb7c-4c65-b208-2a20c6c32fb8]]  -> results: []   (list)
[[HasLabel::BMD_StandardCU_HealthBatt]]            -> results: {..} (dict)
```

Affects single queries, sequential batches and parallel batches. `return_json=True` happened to survive because it returns before that line. `OSW.query_instances()` (`src/osw/core.py:2007`) is affected too, so querying a category with no instances raised instead of returning an empty list.

**2. Silent truncation at `limit` (surfaced here)**

`SearchParam.limit` defaults to 1000 and there is no pagination, so a larger match set is silently reduced to an arbitrary subset. Measured on healthbatt: `[[Category:Item]]` matches 2637 pages, `semantic_search` returned 1000 with no indication.

**3. `exists` flickers server-side (surfaced here, not fixable in this library)**

The `exists == "1"` filter silently discards results. The field only ever takes `'1'` or `''`, but it is not stable: across 8 identical calls, 8 pages flipped between the two, and no page was consistently `''`. The flips are perfectly correlated across pages (calls 0,2,3,4,7 agree; calls 1,5,6 agree), which points at inconsistent state between backends or an SMW query-result cache rather than at real page deletions. Consecutive identical calls returned 998 or 994 titles.

This is the "random results" from #111. It needs to be addressed on the OSL instance side; this PR only makes the loss visible.

## Changes

- `_ask_results_as_dict()` normalises the `ask` payload to a mapping, so an empty result set yields `[]` instead of raising
- `warnings.warn` when the result count meets the requested limit, emitted before the `return_json` early return so both return modes get it
- `warnings.warn` when entries are dropped by the `exists != "1"` filter, naming how many
- 7 unit tests covering zero results in both return modes, sequential and parallel batches with an empty query, both warnings, and the no-warning case

Filter semantics, the default limit, and `prefix_search` are unchanged.

## Verification

- `pytest tests/ --ignore=tests/integration` -> 61 passed, 1 skipped
- New tests confirmed failing first with the expected `AttributeError` / `DID NOT WARN`
- Re-ran the live probes against healthbatt: sequential batch, parallel batch and `return_json` with a zero-result query all return results now instead of raising; both warnings fire with real counts

## Out of scope, noticed while probing

`single_query += f"|limit={query.limit}"` is appended unconditionally, so a caller-supplied limit in the query string is silently overridden: `[[Category:Item]]|limit=2` is sent as `[[Category:Item]]|limit=2|limit=1000` and SMW honours the last one. Verified live (returned 1000, not 2). Not changed here.
