### PR TITLE
feat(wtsite): allow an edit comment on upload_page

### DIFF
--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -624,6 +624,8 @@ class WtSite:
         """If True, uploads the pages in parallel."""
         debug: Optional[bool] = False
         """If True, debug messages will be printed."""
+        comment: Optional[str] = None
+        """Edit comment for the page history, applied to every uploaded page."""
 
         class Config:
             arbitrary_types_allowed = True
@@ -663,7 +665,7 @@ class WtSite:
                     f"WtSite from which this method is called from "
                     f"are not matching!"
                 )
-            page.edit()
+            page.edit(param.comment)
 
             if index is None:
                 print(f"Uploaded page to {page.get_url()}.")

--- a/tests/test_wtsite_upload_page.py
+++ b/tests/test_wtsite_upload_page.py
@@ -1,0 +1,60 @@
+"""Unit tests for WtSite.upload_page().
+
+Regression guard for #112: an edit comment supplied via UploadPageParam must
+reach WtPage.edit(), so bulk uploads are attributable in the page history.
+"""
+
+import threading
+
+from osw.wtsite import WtPage, WtSite
+
+
+class _FakeSite:
+    """Stands in for mwclient.Site, only get_url() touches it."""
+
+    host = "example.org"
+
+
+def _make_fake_wtsite():
+    """A WtSite that performs no network calls."""
+    ws = WtSite.__new__(WtSite)
+    ws._session_lock = threading.RLock()
+    ws._site = _FakeSite()
+    return ws
+
+
+def _make_page(wtsite, title, recorder, monkeypatch):
+    page = WtPage(wtSite=wtsite, title=title, do_init=False)
+    monkeypatch.setattr(page, "edit", lambda comment=None: recorder.append(comment))
+    return page
+
+
+def test_upload_page_forwards_comment(monkeypatch):
+    ws = _make_fake_wtsite()
+    comments = []
+    page = _make_page(ws, "Item:OSW123", comments, monkeypatch)
+
+    ws.upload_page(WtSite.UploadPageParam(pages=page, comment="[bot edit] import"))
+
+    assert comments == ["[bot edit] import"]
+
+
+def test_upload_page_forwards_comment_to_every_page(monkeypatch):
+    ws = _make_fake_wtsite()
+    comments = []
+    pages = [_make_page(ws, f"Item:OSW{i}", comments, monkeypatch) for i in range(3)]
+
+    ws.upload_page(WtSite.UploadPageParam(pages=pages, comment="same for all"))
+
+    assert comments == ["same for all"] * 3
+
+
+def test_upload_page_without_comment_passes_none(monkeypatch):
+    """Default behaviour is unchanged: edit() is called with no comment."""
+    ws = _make_fake_wtsite()
+    comments = []
+    page = _make_page(ws, "Item:OSW123", comments, monkeypatch)
+
+    ws.upload_page(page)
+
+    assert comments == [None]


### PR DESCRIPTION
Closes https://github.com/OpenSemanticLab/osw-python/issues/112

## Changes

- `WtSite.UploadPageParam` gains a `comment` field, mirroring the one on `CopyPagesParam`
- `upload_page` forwards it to `WtPage.edit`, which has accepted a comment all along
- `tests/test_wtsite_upload_page.py`: comment reaches a single page, reaches every page of a batch, and defaults to `None`

## Rationale

`WtPage.edit(comment=...)` already existed, but `upload_page` called a bare `page.edit()`, so bulk uploads landed in the page history unattributed with no way to pass a summary short of editing each page directly.

Default behaviour is unchanged: with no comment set, `edit(None)` is exactly the previous call.