### PR TITLE
fix(core): write a stub for a $ref whose page does not exist

### DIFF
--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -71,6 +71,46 @@ from osw.wtsite import WtPage, WtSite
 _logger = logging.getLogger(__name__)
 
 
+def get_model_dir_path() -> str:
+    """The directory the fetched json schemas are written to"""
+    return os.path.join(os.path.dirname(os.path.abspath(__file__)), "model")
+
+
+def write_schema_stub(model_dir_path: str, schema_name: str) -> str:
+    """Writes an empty schema, so a $ref pointing at it still resolves
+
+    A $ref is rewritten to a local file name before the page it names is
+    fetched. When that page turns out not to exist, nothing writes the file,
+    and datamodel-code-generator later fails with FileNotFoundError far away
+    from the cause. An empty schema keeps generation going, and the reason is
+    reported in the FetchSchemaResult instead.
+    """
+    schema_path = os.path.join(model_dir_path, schema_name + ".json")
+    os.makedirs(os.path.dirname(schema_path), exist_ok=True)
+    with open(schema_path, "w", encoding="utf-8") as f:
+        f.write("{}")
+    return schema_path
+
+
+def collect_messages(
+    target: Optional[List[str]], source: Optional[List[str]]
+) -> Optional[List[str]]:
+    """Adds the messages in source to target, skipping duplicates
+
+    _FetchSchemaParam is copied shallowly for a recursive fetch, so target and
+    source can be the very same list. That case is already merged and is left
+    alone rather than iterated while being appended to.
+    """
+    if not source or target is source:
+        return target
+    if target is None:
+        target = []
+    for message in source:
+        if message not in target:
+            target.append(message)
+    return target
+
+
 # Reusable type definitions
 class OverwriteOptions(Enum):
     """Options for overwriting properties"""
@@ -477,13 +517,15 @@ class OSW(BaseModel):
 
         # merge unique results and return
         merged_result = OSW.FetchSchemaResult(
-            fetched_schema_titles=[], error_messages=[]
+            fetched_schema_titles=[], error_messages=[], warning_messages=[]
         )
         for result in results:
             if result.fetched_schema_titles:
                 merged_result.fetched_schema_titles.extend(result.fetched_schema_titles)
             if result.error_messages:
                 merged_result.error_messages.extend(result.error_messages)
+            if result.warning_messages:
+                merged_result.warning_messages.extend(result.warning_messages)
         return OSW.FetchSchemaResult(
             fetched_schema_titles=(
                 list(set(merged_result.fetched_schema_titles))
@@ -493,6 +535,11 @@ class OSW(BaseModel):
             error_messages=(
                 list(set(merged_result.error_messages))
                 if len(merged_result.error_messages) > 0
+                else None
+            ),
+            warning_messages=(
+                list(set(merged_result.warning_messages))
+                if len(merged_result.warning_messages) > 0
                 else None
             ),
         )
@@ -569,6 +616,8 @@ class OSW(BaseModel):
             ]
             if not page.exists:
                 print(f"Error: Page {schema_title} does not exist")
+                # the $ref that led here was already rewritten to this file name
+                write_schema_stub(get_model_dir_path(), schema_name)
                 return OSW.FetchSchemaResult(
                     fetched_schema_titles=fetchSchemaParam.fetched_schema_titles,
                     warning_messages=fetchSchemaParam.warning_messages,
@@ -606,6 +655,7 @@ class OSW(BaseModel):
         schema = json.loads(schema_str.replace("$ref", "dollarref"))
 
         jsonpath_expr = parse("$..dollarref")
+        ref_error_messages = None
         for match in jsonpath_expr.find(schema):
             # value = "https://" + self.mw_site.host + match.value
             if match.value.startswith("#"):
@@ -628,11 +678,18 @@ class OSW(BaseModel):
                 _param = fetchSchemaParam.copy()
                 _param.root = False
                 _param.schema_title = ref_schema_title
-                self._fetch_schema(_param)  # resolve references recursive
+                ref_result = self._fetch_schema(_param)  # resolve refs recursive
+                # the recursive call is the only place that knows why a
+                # referenced schema could not be fetched, so its messages have
+                # to be carried up rather than dropped
+                ref_error_messages = collect_messages(
+                    ref_error_messages, ref_result.error_messages
+                )
+                fetchSchemaParam.warning_messages = collect_messages(
+                    fetchSchemaParam.warning_messages, ref_result.warning_messages
+                )
 
-        model_dir_path = os.path.join(
-            os.path.dirname(os.path.abspath(__file__)), "model"
-        )  # src/model
+        model_dir_path = get_model_dir_path()  # src/model
         schema_path = os.path.join(model_dir_path, schema_name + ".json")
         os.makedirs(os.path.dirname(schema_path), exist_ok=True)
         with open(schema_path, "w", encoding="utf-8") as f:
@@ -1005,6 +1062,7 @@ class OSW(BaseModel):
         return OSW.FetchSchemaResult(
             fetched_schema_titles=fetchSchemaParam.fetched_schema_titles,
             warning_messages=fetchSchemaParam.warning_messages,
+            error_messages=ref_error_messages,
         )
 
     def install_dependencies(

--- a/tests/test_schema_ref_stub.py
+++ b/tests/test_schema_ref_stub.py
@@ -1,0 +1,83 @@
+"""Unit tests for the missing-schema-page handling in osw.core.
+
+Regression guard for #134: a $ref is rewritten to a local file name before the
+page it names is fetched. When that page does not exist, no file was written
+and no message reached the caller, so the failure surfaced much later as a
+FileNotFoundError inside datamodel-code-generator.
+"""
+
+import json
+import os
+
+import pytest
+
+from osw.core import collect_messages, get_model_dir_path, write_schema_stub
+
+
+def test_stub_is_valid_empty_json(tmp_path):
+    path = write_schema_stub(str(tmp_path), "undefined")
+
+    with open(path, encoding="utf-8") as f:
+        assert json.load(f) == {}
+
+
+def test_stub_lands_where_the_rewritten_ref_points(tmp_path):
+    """The $ref becomes '<name>.json' relative to the model dir."""
+    path = write_schema_stub(str(tmp_path), "undefined")
+
+    assert os.path.basename(path) == "undefined.json"
+    assert os.path.dirname(path) == str(tmp_path)
+
+
+def test_stub_creates_missing_directories(tmp_path):
+    target = tmp_path / "nested" / "deeper"
+
+    path = write_schema_stub(str(target), "undefined")
+
+    assert os.path.isfile(path)
+
+
+def test_stub_overwrites_an_existing_file(tmp_path):
+    (tmp_path / "undefined.json").write_text('{"stale": true}', encoding="utf-8")
+
+    path = write_schema_stub(str(tmp_path), "undefined")
+
+    with open(path, encoding="utf-8") as f:
+        assert json.load(f) == {}
+
+
+def test_model_dir_is_next_to_core():
+    model_dir = get_model_dir_path()
+
+    assert os.path.basename(model_dir) == "model"
+    assert os.path.isfile(os.path.join(model_dir, "entity.py"))
+
+
+@pytest.mark.parametrize("source", [None, []])
+def test_nothing_to_collect_leaves_the_target_alone(source):
+    assert collect_messages(None, source) is None
+    assert collect_messages(["a"], source) == ["a"]
+
+
+def test_messages_are_collected_into_an_absent_target():
+    assert collect_messages(None, ["a"]) == ["a"]
+
+
+def test_messages_are_appended_without_duplicates():
+    assert collect_messages(["a"], ["a", "b"]) == ["a", "b"]
+
+
+def test_a_shared_list_is_not_iterated_while_appended_to():
+    """_FetchSchemaParam.copy() is shallow, so both sides can be one list."""
+    shared = ["a"]
+
+    assert collect_messages(shared, shared) is shared
+    assert shared == ["a"]
+
+
+def test_collecting_does_not_mutate_the_source():
+    source = ["b"]
+
+    collect_messages(["a"], source)
+
+    assert source == ["b"]


### PR DESCRIPTION
Closes https://github.com/OpenSemanticLab/osw-python/issues/134.

## Changes

- `write_schema_stub` in `src/osw/core.py`: writes `{}` for a schema page that does not exist, so the already-rewritten `$ref` still resolves on disk.
- `_fetch_schema` now keeps the result of its recursive call and carries the referenced schema's `error_messages` and `warning_messages` up to the caller instead of discarding them.
- `fetch_schema` merges `warning_messages` as well. It only merged `error_messages`, so every warning raised below it was dropped.
- `get_model_dir_path` so the stub writer and the normal schema writer agree on the location.
- `collect_messages` for the merge itself.
- `tests/test_schema_ref_stub.py`: 11 offline tests.

## Rationale

`_fetch_schema` rewrites a `$ref` to a local file name before it fetches the page that `$ref` names. When that page does not exist it returns early, so nothing writes the file and nothing reports the reason. The `$ref` is already pointing at it by then, and the failure surfaces much later as a `FileNotFoundError` from `datamodel-code-generator`, with no indication of which page was missing.

Writing an empty schema keeps generation going and moves the explanation into the returned `FetchSchemaResult`. This is what `core.py` already does for the sibling case, a page that exists with an empty `jsonschema` slot.

The recursive result was assigned to nothing at all, so even before this change no message from a referenced schema could reach the caller. Fixing the stub without also fixing that would have written the reason to a value nobody reads.

## Notes

- `_FetchSchemaParam.copy()` is a pydantic v1 shallow copy, so a recursive call can share its message list with its parent. `collect_messages` returns early when target and source are the same object, rather than iterating a list while appending to it. `test_a_shared_list_is_not_iterated_while_appended_to` pins that.
- The `fetch_schema` warning drop was found while writing these tests and is fixed here rather than filed separately.
- Deduplication on append keeps a schema referenced from several places from repeating its message once per reference.

## Verification

Offline suite passes (65 passed, 1 skipped).
