### PR TITLE
feat(controller): add a uri property to every file controller

### DIFF
--- a/src/osw/controller/file/base.py
+++ b/src/osw/controller/file/base.py
@@ -1,11 +1,21 @@
 from abc import abstractmethod
-from typing import IO, Any, Dict
+from typing import IO, Any, Dict, Optional
 
 from osw.core import model
 
 
 class FileController(model.File):
     """Base class for file controllers"""
+
+    @property
+    @abstractmethod
+    def uri(self) -> Optional[str]:
+        """The location of the file, in the URI scheme of its storage backend
+
+        Returns
+        -------
+            the URI, or None if the file is not stored anywhere addressable
+        """
 
     @abstractmethod
     def get(self) -> IO:

--- a/src/osw/controller/file/base.py
+++ b/src/osw/controller/file/base.py
@@ -8,14 +8,23 @@ class FileController(model.File):
     """Base class for file controllers"""
 
     @property
-    @abstractmethod
     def uri(self) -> Optional[str]:
         """The location of the file, in the URI scheme of its storage backend
 
+        The read interface for a location: derived on every access, never stored,
+        so it cannot go stale. Each controller keeps the handle its backend
+        actually needs, e.g., a Path in LocalFileController.path, and answers
+        here in its own scheme.
+
+        Not abstract on purpose. pydantic's ModelMetaclass extends ABCMeta, so an
+        abstract property would stop every file controller outside this package
+        that predates it from being instantiated.
+
         Returns
         -------
-            the URI, or None if the file is not stored anywhere addressable
+            the URI, or None if the controller does not name a location
         """
+        return None
 
     @abstractmethod
     def get(self) -> IO:

--- a/src/osw/controller/file/local.py
+++ b/src/osw/controller/file/local.py
@@ -29,6 +29,12 @@ class LocalFileController(FileController, model.LocalFile):
         super().__init__(**kwargs)
         self._set_metadata()
 
+    @property
+    def uri(self) -> str:
+        """The file URI of the path, see
+        https://en.wikipedia.org/wiki/File_URI_scheme"""
+        return Path(self.path).absolute().as_uri()
+
     def get(self) -> IO:
         self._set_metadata()
         return open(self.path, "rb")

--- a/src/osw/controller/file/memory.py
+++ b/src/osw/controller/file/memory.py
@@ -21,6 +21,11 @@ class InMemoryController(FileController, model.LocalFile):
     class Config:
         arbitrary_types_allowed = True
 
+    @property
+    def uri(self) -> None:
+        """None, a stream in memory has no location to address"""
+        return None
+
     def get(self) -> IO:
         return self.stream
 

--- a/src/osw/controller/file/remote.py
+++ b/src/osw/controller/file/remote.py
@@ -15,7 +15,12 @@ class RemoteFileController(model.RemoteFile, FileController):
     @property
     def uri(self) -> str:
         """The url the file is stored at, e.g., 's3://' for S3FileController and
-        'https://' for WikiFileController"""
+        'https://' for WikiFileController
+
+        A remote controller keeps its location in 'url', either as a field of its
+        data model, as model.S3File does, or as a property, as WikiFileController
+        does. model.RemoteFile does not declare it, so this is a contract between
+        the subclasses rather than something the base class can enforce."""
         return self.url
 
     @abstractmethod

--- a/src/osw/controller/file/remote.py
+++ b/src/osw/controller/file/remote.py
@@ -12,6 +12,12 @@ from osw.core import model
 # The data class must be the first base class, otherwise subclass controllers fall back
 #  to the data model of the controller superclass
 class RemoteFileController(model.RemoteFile, FileController):
+    @property
+    def uri(self) -> str:
+        """The url the file is stored at, e.g., 's3://' for S3FileController and
+        'https://' for WikiFileController"""
+        return self.url
+
     @abstractmethod
     def get(self) -> IO:
         pass

--- a/tests/test_file_controller_uri.py
+++ b/tests/test_file_controller_uri.py
@@ -8,6 +8,7 @@ from pathlib import Path
 from types import SimpleNamespace
 from typing import IO, Any, Dict
 
+from osw.controller.file.base import FileController
 from osw.controller.file.local import LocalFileController
 from osw.controller.file.memory import InMemoryController
 from osw.controller.file.remote import RemoteFileController
@@ -25,6 +26,25 @@ class OfflineRemoteFileController(RemoteFileController):
 
     def put(self, file: IO, **kwargs: Dict[str, Any]):
         pass
+
+
+class ControllerWithoutUri(FileController):
+    """A controller written before uri existed, as a third party one would be"""
+
+    def get(self) -> IO:
+        pass
+
+    def put(self, file: IO, **kwargs: Dict[str, Any]):
+        pass
+
+
+def test_a_controller_that_predates_uri_still_works():
+    """uri is deliberately not abstract: pydantic's ModelMetaclass extends
+    ABCMeta, so an abstract property would break every controller outside this
+    package that does not know about it yet."""
+    controller = ControllerWithoutUri(label=[model.Label(text="Unnamed file")])
+
+    assert controller.uri is None
 
 
 def test_local_uri_is_a_file_url(tmp_path):

--- a/tests/test_file_controller_uri.py
+++ b/tests/test_file_controller_uri.py
@@ -1,0 +1,81 @@
+"""Offline tests for the uri property of the file controllers.
+
+Covers #68: every controller reports where its file lives, in the URI scheme of
+its own storage backend.
+"""
+
+from pathlib import Path
+from types import SimpleNamespace
+from typing import IO, Any, Dict
+
+from osw.controller.file.local import LocalFileController
+from osw.controller.file.memory import InMemoryController
+from osw.controller.file.remote import RemoteFileController
+from osw.controller.file.wiki import WikiFileController
+from osw.core import model
+
+
+class OfflineRemoteFileController(RemoteFileController):
+    """A remote controller carrying nothing but a url, as model.S3File does"""
+
+    url: str
+
+    def get(self) -> IO:
+        pass
+
+    def put(self, file: IO, **kwargs: Dict[str, Any]):
+        pass
+
+
+def test_local_uri_is_a_file_url(tmp_path):
+    path = tmp_path / "test.txt"
+    path.write_text("content", encoding="utf-8")
+
+    uri = LocalFileController(path=path).uri
+
+    assert uri.startswith("file:///")
+    assert uri.endswith("/test.txt")
+
+
+def test_local_uri_is_absolute_for_a_relative_path(tmp_path, monkeypatch):
+    """as_uri() rejects a relative path, so the path has to be resolved first."""
+    monkeypatch.chdir(tmp_path)
+
+    uri = LocalFileController(path=Path("test.txt")).uri
+
+    assert uri == (Path.cwd() / "test.txt").as_uri()
+
+
+def test_local_uri_escapes_reserved_characters(tmp_path):
+    uri = LocalFileController(path=tmp_path / "a file.txt").uri
+
+    assert uri.endswith("/a%20file.txt")
+
+
+def test_in_memory_uri_is_none():
+    """A stream has no location, so there is nothing to point at."""
+    assert InMemoryController().uri is None
+
+
+def test_remote_uri_is_the_url():
+    url = "s3://s3.example.org/bucket/OSW0000.txt"
+    controller = OfflineRemoteFileController(
+        url=url, label=[model.Label(text="OSW0000.txt")]
+    )
+
+    assert controller.uri == url
+
+
+def test_wiki_uri_is_the_file_page_url():
+    """WikiFileController builds url itself, so uri needs no override there."""
+    page = SimpleNamespace(
+        osw=SimpleNamespace(
+            mw_site=SimpleNamespace(scheme="https", host="wiki.example.org")
+        ),
+        title="OSW0000.txt",
+    )
+
+    url = WikiFileController.url.fget(page)
+
+    assert url == "https://wiki.example.org/wiki/File:OSW0000.txt"
+    assert RemoteFileController.uri.fget(SimpleNamespace(url=url)) == url


### PR DESCRIPTION
Closes https://github.com/OpenSemanticLab/osw-python/issues/68.

Stacked on https://github.com/OpenSemanticLab/osw-python/pull/148, which makes `InMemoryController` constructible. Merge that first, this base retargets to `main` automatically.

## Changes

- `FileController.uri`: the location of the file in the URI scheme of its storage backend. Concrete, returns `None` by default.
- `LocalFileController.uri`: `file://`, via `Path.absolute().as_uri()`, see https://en.wikipedia.org/wiki/File_URI_scheme.
- `RemoteFileController.uri`: the stored `url`. `S3FileController` and `WikiFileController` inherit it, so they report `s3://...` and `https://.../wiki/File:...` without an override.
- `InMemoryController.uri`: `None`.
- `tests/test_file_controller_uri.py`: 7 offline tests.

## Rationale

A caller holding a `FileController` had no way to ask where the file actually is. Each subclass kept that in a different shape: a `Path`, a `url`, or nothing at all.

`WikiFileController` already builds the page url in its `url` property (`src/osw/controller/file/wiki.py:167`), and `S3FileController` parses `self.url` for its bucket and key, so putting `uri` on `RemoteFileController` covers both from what they already carry.

`uri` is a read interface: derived on every access, never stored, so it cannot go stale. Each controller keeps the handle its backend actually needs and answers `uri` in its own scheme. The wider harmonization of `path` / `url` / `uri`, and a `from_uri()` write-side counterpart, are proposed in https://github.com/OpenSemanticLab/osw-python/issues/68#issuecomment-5511512476 and are out of scope here.

## Notes

- The property is deliberately not abstract. pydantic v1's `ModelMetaclass` extends `ABCMeta`, so `@abstractmethod` is enforced at instantiation and an abstract `uri` would break every file controller outside this package that predates it. A concrete `None` default keeps this a `feat`, not a breaking change.
- `InMemoryController` returns `None` rather than raising. A stream is a legitimate file source, it just has no address.

## Verification

Offline suite passes (66 passed, 1 skipped). The wiki and S3 controllers need a live backend, so their `uri` is covered through `RemoteFileController` and, for the wiki page url, by calling the property directly on a stand-in.
