### PR TITLE
feat(express): let a download keep the original file name

### DIFF
--- a/src/osw/express.py
+++ b/src/osw/express.py
@@ -13,6 +13,7 @@ directory, which is based on the current working directory
 import importlib.util
 import os
 import re
+from enum import Enum
 from io import TextIOWrapper
 from pathlib import Path
 from typing import overload
@@ -409,6 +410,74 @@ class FileResult(OswBaseModel):
         return data
 
 
+class FilenameMode(Enum):
+    """Options for the file name a download is saved under"""
+
+    osw_id = "osw_id"
+    """The OSW-ID and the suffixes, as the file is named on the wiki, e.g.,
+    'OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt'"""
+    name = "name"
+    """The original file name and the suffixes, e.g., 'My_textfile.txt'"""
+    name_and_osw_id = "name_and_osw_id"
+    """Both, separated by an underscore, e.g.,
+    'My_textfile_OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt'"""
+
+
+def build_target_fn(
+    mode: Union[FilenameMode, str], osw_id_fn: str, name: Optional[str]
+) -> str:
+    """Builds the file name a download is saved under
+
+    Parameters
+    ----------
+    mode
+        which of the forms listed in FilenameMode to build
+    osw_id_fn
+        the name of the file on the wiki, the OSW-ID and the suffixes, e.g.,
+        'OSW02a0e8a917594129b3b8f2f48e2c3f7f.drawio.png'
+    name
+        the original file name, stored in the JSON data of the file page. The
+        OSW-ID form is used if it is empty, since the other forms have nothing to
+        build on then.
+
+    Returns
+    -------
+        the file name, without a directory
+    """
+    mode = FilenameMode(mode)
+    if mode == FilenameMode.osw_id:
+        return osw_id_fn
+    if not name:
+        warn(
+            f"No name is stored for '{osw_id_fn}', falling back to the OSW-ID as "
+            f"the file name."
+        )
+        return osw_id_fn
+    # the OSW-ID itself carries no dot, so every dot in osw_id_fn opens a suffix
+    suffixes = "".join(Path(osw_id_fn).suffixes)
+    osw_id = osw_id_fn[: len(osw_id_fn) - len(suffixes)]
+    stem = Path(name).name
+    if suffixes and stem.endswith(suffixes):
+        # the name is stored without the suffixes, but does not have to be
+        stem = stem[: -len(suffixes)]
+    if mode == FilenameMode.name:
+        return f"{stem}{suffixes}"
+    return f"{stem}_{osw_id}{suffixes}"
+
+
+def _load_wiki_file(data: Dict[str, Any], url_or_title: str) -> WikiFileController:
+    """Loads the file page and returns it as a file controller, creating the
+    OswExpress instance in data if there is none yet"""
+    if data.get("osw_express") is None:
+        data["osw_express"] = OswExpress(
+            domain=data.get("domain"),
+            cred_mngr=data.get("cred_mngr"),
+        )
+    title: str = "File:" + url_or_title.split("File:")[-1]
+    file = data.get("osw_express").load_entity(title)
+    return file.cast(WikiFileController, osw=data.get("osw_express"))
+
+
 class DownloadFileResult(FileResult, LocalFileController):
     """A specific result object to describe the result of downloading a file from an
     OSL instance."""
@@ -419,8 +488,11 @@ class DownloadFileResult(FileResult, LocalFileController):
     """The target directory to download the file to. If None, the current working
     will be used."""
     target_fn: Optional[str] = None
-    """The target filename to save the file as. If None, the filename will be taken
-    from the URL or title."""
+    """The target filename to save the file as. If None, the filename will be built
+    according to 'target_fn_mode'."""
+    target_fn_mode: FilenameMode = FilenameMode.osw_id
+    """How to build the target filename if 'target_fn' is None. See FilenameMode.
+    Defaults to the OSW-ID, the name the file has on the wiki."""
     target_fp: Optional[Union[str, Path]] = None
     """The target filepath to save the file to. If None, the file will be saved to the
     target directory with the target filename."""
@@ -443,23 +515,6 @@ class DownloadFileResult(FileResult, LocalFileController):
         data["url_or_title"] = url_or_title
         # Do replacements
         data = self.process_init_data(data)
-        if data.get("target_fn") is None:
-            data["target_fn"] = url_or_title.split("File:")[-1]
-        if data.get("target_dir") is None:
-            # Take target_dir from environment variables
-            if os.getenv("OSW_DOWNLOAD_DIR") is not None:
-                data["target_dir"] = os.getenv("OSW_DOWNLOAD_DIR")
-            elif os.getenv("OSL_DOWNLOAD_DIR") is not None:
-                data["target_dir"] = os.getenv("OSL_DOWNLOAD_DIR")
-            # Fallback to the package default (based on CWD)
-            else:
-                data["target_dir"] = default_paths.download_dir
-        if isinstance(data.get("target_dir"), str):
-            data["target_dir"] = Path(data.get("target_dir"))
-        if data.get("target_fp") is None:
-            data["target_fp"] = data.get("target_dir") / data.get("target_fn")
-        # Setting path after all operations on target_fp are complete
-        data["path"] = data.get("target_fp")
         if data.get("domain") is None:
             match = re.search(
                 pattern=r"(?:(?:https?:\/\/)?(?:www\.)?([^\/]+))\/wiki",
@@ -477,6 +532,34 @@ class DownloadFileResult(FileResult, LocalFileController):
                     )
             else:
                 data["domain"] = match.group(1)
+        if data.get("target_dir") is None:
+            # Take target_dir from environment variables
+            if os.getenv("OSW_DOWNLOAD_DIR") is not None:
+                data["target_dir"] = os.getenv("OSW_DOWNLOAD_DIR")
+            elif os.getenv("OSL_DOWNLOAD_DIR") is not None:
+                data["target_dir"] = os.getenv("OSL_DOWNLOAD_DIR")
+            # Fallback to the package default (based on CWD)
+            else:
+                data["target_dir"] = default_paths.download_dir
+        if isinstance(data.get("target_dir"), str):
+            data["target_dir"] = Path(data.get("target_dir"))
+        wf: Optional[WikiFileController] = None
+        """The file controller, loaded early if the target filename depends on it"""
+        if data.get("target_fn") is None:
+            osw_id_fn = url_or_title.split("File:")[-1]
+            if FilenameMode(data.get("target_fn_mode")) == FilenameMode.osw_id:
+                data["target_fn"] = osw_id_fn
+            else:
+                # the original name is stored in the JSON data of the file page, so
+                # the page has to be loaded before the target path is known
+                wf = _load_wiki_file(data, url_or_title)
+                data["target_fn"] = build_target_fn(
+                    data.get("target_fn_mode"), osw_id_fn, wf.name
+                )
+        if data.get("target_fp") is None:
+            data["target_fp"] = data.get("target_dir") / data.get("target_fn")
+        # Setting path after all operations on target_fp are complete
+        data["path"] = data.get("target_fp")
         if data.get("use_cached") and data.get("target_fp").exists():
             # Here, no file needs to be downloaded, but self need to be initialized
             #  with the path to the file
@@ -484,17 +567,8 @@ class DownloadFileResult(FileResult, LocalFileController):
             data = {key: value for key, value in data.items() if value is not None}
             super().__init__(**data)  # data includes "path"
         else:
-            if data.get("osw_express") is None:
-                data["osw_express"] = OswExpress(
-                    domain=data.get("domain"),
-                    cred_mngr=data.get("cred_mngr"),
-                )
-            title: str = "File:" + url_or_title.split("File:")[-1]
-            file = data.get("osw_express").load_entity(title)
-            wf: WikiFileController = file.cast(
-                WikiFileController, osw=data.get("osw_express")
-            )
-            """The file controller"""
+            if wf is None:
+                wf = _load_wiki_file(data, url_or_title)
             if data.get("target_fp").exists() and not data.get("overwrite"):
                 raise FileExistsError(
                     f"File already exists: {data.get('target_fp')}. Set "
@@ -516,6 +590,7 @@ def osw_download_file(
     delete_after_use: bool = False,
     target_dir: Optional[Union[str, Path]] = None,
     target_fn: Optional[str] = None,
+    target_fn_mode: Union[FilenameMode, str] = FilenameMode.osw_id,
     target_fp: Optional[Union[str, Path]] = None,
     osw_express: Optional[OswExpress] = None,
     domain: Optional[str] = None,
@@ -538,8 +613,15 @@ def osw_download_file(
         The target directory to download the file to. If None, the current working
         will be used.
     target_fn
-        The target filename to save the file as. If None, the filename will be taken
-        from the URL or title.
+        The target filename to save the file as. If None, the filename will be built
+        according to target_fn_mode.
+    target_fn_mode
+        How to build the target filename if target_fn is None. One of
+        FilenameMode.osw_id ('OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt', the default),
+        FilenameMode.name ('My_textfile.txt') or FilenameMode.name_and_osw_id
+        ('My_textfile_OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt'). The latter two read
+        the original name from the file page, so they load it even when use_cached
+        is set.
     target_fp
         The target filepath to save the file to. If None, the file will be saved to the
         target directory with the target filename.
@@ -577,6 +659,7 @@ def osw_download_file(
         delete_after_use=delete_after_use,
         target_dir=target_dir,
         target_fn=target_fn,
+        target_fn_mode=target_fn_mode,
         target_fp=target_fp,
         osw_express=osw_express,
         domain=domain,

--- a/tests/test_download_filename_modes.py
+++ b/tests/test_download_filename_modes.py
@@ -1,0 +1,77 @@
+"""Offline tests for the target filename of osw.express downloads.
+
+Covers #94: a download can keep the OSW-ID it has on the wiki, use the original
+file name, or combine both.
+"""
+
+import pytest
+
+from osw.express import FilenameMode, build_target_fn
+
+OSW_ID_FN = "OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt"
+
+
+@pytest.mark.parametrize("mode", [FilenameMode.osw_id, "osw_id"])
+def test_osw_id_mode_keeps_the_wiki_filename(mode):
+    """The default, unchanged from before the modes existed."""
+    assert build_target_fn(mode, OSW_ID_FN, "My_textfile") == OSW_ID_FN
+
+
+def test_name_mode_uses_the_original_name():
+    assert build_target_fn(FilenameMode.name, OSW_ID_FN, "My_textfile") == (
+        "My_textfile.txt"
+    )
+
+
+def test_name_and_osw_id_mode_uses_both():
+    assert build_target_fn(FilenameMode.name_and_osw_id, OSW_ID_FN, "My_textfile") == (
+        "My_textfile_OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt"
+    )
+
+
+@pytest.mark.parametrize(
+    "mode", [FilenameMode.name, FilenameMode.name_and_osw_id, FilenameMode.osw_id]
+)
+def test_every_suffix_is_carried_over(mode):
+    """The OSW-ID carries no dot, so '.drawio.png' is one suffix, not two."""
+    osw_id_fn = "OSW02a0e8a917594129b3b8f2f48e2c3f7f.drawio.png"
+
+    assert build_target_fn(mode, osw_id_fn, "My_drawing").endswith(".drawio.png")
+
+
+def test_a_name_that_still_carries_the_suffix_does_not_double_it():
+    """WikiFileController strips the suffix off name, but not every page has it."""
+    assert build_target_fn(FilenameMode.name, OSW_ID_FN, "My_textfile.txt") == (
+        "My_textfile.txt"
+    )
+
+
+def test_dots_inside_the_name_are_kept():
+    assert build_target_fn(FilenameMode.name, OSW_ID_FN, "v1.2.3_report") == (
+        "v1.2.3_report.txt"
+    )
+
+
+def test_a_file_without_a_suffix_gets_none():
+    osw_id_fn = "OSW02a0e8a917594129b3b8f2f48e2c3f7f"
+
+    assert build_target_fn(FilenameMode.name, osw_id_fn, "My_textfile") == "My_textfile"
+
+
+def test_a_directory_in_the_name_is_dropped():
+    """The name comes from the wiki, so it must not steer the download elsewhere."""
+    result = build_target_fn(FilenameMode.name, OSW_ID_FN, "../../etc/passwd")
+
+    assert result == "passwd.txt"
+
+
+@pytest.mark.parametrize("name", [None, ""])
+@pytest.mark.parametrize("mode", [FilenameMode.name, FilenameMode.name_and_osw_id])
+def test_a_missing_name_falls_back_to_the_osw_id(mode, name):
+    with pytest.warns(UserWarning, match="No name is stored"):
+        assert build_target_fn(mode, OSW_ID_FN, name) == OSW_ID_FN
+
+
+def test_an_unknown_mode_is_rejected():
+    with pytest.raises(ValueError):
+        build_target_fn("original", OSW_ID_FN, "My_textfile")


### PR DESCRIPTION
Closes https://github.com/OpenSemanticLab/osw-python/issues/94.

## Changes

- `FilenameMode` in `src/osw/express.py`, with the three forms the issue lists:
  - `osw_id`: `OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt`, the name on the wiki. Unchanged default.
  - `name`: `My_textfile.txt`
  - `name_and_osw_id`: `My_textfile_OSW02a0e8a917594129b3b8f2f48e2c3f7f.txt`
- `target_fn_mode` on `osw_download_file` and `DownloadFileResult`.
- `build_target_fn` builds the name from the wiki file name and the stored original name.
- `_load_wiki_file` collects the page load that `DownloadFileResult.__init__` now does from two places.
- `tests/test_download_filename_modes.py`: 16 offline tests.

## Rationale

`DownloadFileResult` took the target file name straight from the url or page title, so a download always landed as the OSW-ID. The original name is already stored in the JSON data of the file page, put there by `WikiFileController._init` on upload, so nothing new has to be recorded to offer the other two forms.

The default stays the OSW-ID, so existing callers see no change.

## Notes

- The two new modes read the original name from the file page, so they load it even when `use_cached` is set. The name is not knowable without it. `osw_id` still resolves the path without any request.
- Domain resolution moved above the target path so the early load has a domain to work with. Same logic, same inputs, only the position changed.
- A page with no stored name falls back to the OSW-ID form and warns. Files predating the name being written have nothing else to go on.
- The stored name is reduced to its last path segment, so a name from the wiki cannot redirect the download out of the target directory.
- Every suffix is kept, not just the last. The OSW-ID carries no dot, so `OSW....drawio.png` yields `My_drawing.drawio.png`.
- Upload needs no option of its own: it already stores the original name, and the wiki page title stays the OSW-ID, which is what identifies the file.

## Verification

Offline suite passes (70 passed, 1 skipped). The tests cover `build_target_fn` directly. The full download path needs a live instance, so the round trip has not been run here.
