### PR TITLE
feat(logging): replace print statements with the logging module

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,24 @@ More runnable scripts live in [examples/](examples/), and the
 [Basics tutorial](docs/tutorials/basics.ipynb) walks through the
 OpenSemanticLab data model.
 
+## Logging
+
+osw reports what it is doing through the standard `logging` module, on the
+`osw` logger, at INFO by default:
+
+```python
+import osw
+
+osw.set_log_level("WARNING")  # see less
+osw.set_log_level("DEBUG")    # see more
+osw.disable_logging()         # detach the handler osw attached
+```
+
+Set `OSW_LOG_LEVEL` to a level name, a level number, or `OFF` to choose the
+level before the package is imported. `disable_logging()` also restores
+propagation to the root logger, so an application that prefers to configure
+handlers itself can take over with `logging.basicConfig()`.
+
 ## Contributing
 
 Contributions are welcome, see [CONTRIBUTING.md](CONTRIBUTING.md).

--- a/README.md
+++ b/README.md
@@ -53,9 +53,34 @@ osw.disable_logging()         # detach the handler osw attached
 ```
 
 Set `OSW_LOG_LEVEL` to a level name, a level number, or `OFF` to choose the
-level before the package is imported. `disable_logging()` also restores
-propagation to the root logger, so an application that prefers to configure
-handlers itself can take over with `logging.basicConfig()`.
+level before the package is imported. `OFF` silences osw everywhere, including
+in your own handlers.
+
+### Collecting osw's records in your application
+
+Configure logging the way you normally would and osw's records arrive there,
+once:
+
+```python
+import logging
+import osw
+
+logging.basicConfig(level=logging.INFO, filename="app.log")
+```
+
+The `osw` logger propagates at all times, so the records reach your handlers
+whatever else happens. osw's own handler notices that something above it is
+listening, detaches itself so nothing is written twice, and gives back the
+level it had picked, so your level applies from then on. It makes no difference
+whether you configure logging before or after importing osw.
+
+A level you asked for is kept across that hand-over, so `set_log_level("DEBUG")`
+or `OSW_LOG_LEVEL=DEBUG` is how you pull osw's debug records into an aggregated
+setup while the rest of your application stays quieter.
+
+One case osw cannot detect is a handler added to the `osw` logger itself, since
+that is indistinguishable from one of its own. Call `disable_logging()` first if
+you do that.
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -41,46 +41,10 @@ OpenSemanticLab data model.
 
 ## Logging
 
-osw reports what it is doing through the standard `logging` module, on the
-`osw` logger, at INFO by default:
-
-```python
-import osw
-
-osw.set_log_level("WARNING")  # see less
-osw.set_log_level("DEBUG")    # see more
-osw.disable_logging()         # detach the handler osw attached
-```
-
-Set `OSW_LOG_LEVEL` to a level name, a level number, or `OFF` to choose the
-level before the package is imported. `OFF` silences osw everywhere, including
-in your own handlers.
-
-### Collecting osw's records in your application
-
-Configure logging the way you normally would and osw's records arrive there,
-once:
-
-```python
-import logging
-import osw
-
-logging.basicConfig(level=logging.INFO, filename="app.log")
-```
-
-The `osw` logger propagates at all times, so the records reach your handlers
-whatever else happens. osw's own handler notices that something above it is
-listening, detaches itself so nothing is written twice, and gives back the
-level it had picked, so your level applies from then on. It makes no difference
-whether you configure logging before or after importing osw.
-
-A level you asked for is kept across that hand-over, so `set_log_level("DEBUG")`
-or `OSW_LOG_LEVEL=DEBUG` is how you pull osw's debug records into an aggregated
-setup while the rest of your application stays quieter.
-
-One case osw cannot detect is a handler added to the `osw` logger itself, since
-that is indistinguishable from one of its own. Call `disable_logging()` first if
-you do that.
+osw reports what it is doing on the `osw` logger at INFO by default. Levels,
+the `OSW_LOG_LEVEL` environment variable and how to collect the records in your
+own logging setup are described in the
+[Get Started guide](https://opensemanticlab.github.io/osw-python/get-started/#logging).
 
 ## Contributing
 

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -77,6 +77,10 @@ osw.set_log_level("DEBUG")    # see more
 osw.disable_logging()         # detach the handler osw attached
 ```
 
+The records go to `stderr`, which leaves `stdout` free for your program's own
+output. That matters for anything speaking a protocol over `stdout`, such as an
+MCP stdio server. Pass `osw.enable_logging(stream=...)` to send them elsewhere.
+
 Set `OSW_LOG_LEVEL` to a level name, a level number, or `OFF` to choose the
 level before the package is imported. `OFF` silences osw everywhere, including
 in your own handlers.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -77,6 +77,12 @@ osw.set_log_level("DEBUG")    # see more
 osw.disable_logging()         # detach the handler osw attached
 ```
 
+Problems that osw can work around are WARNING records on the same logger, not
+Python `warnings`. A truncated query result and a page that does not exist are
+examples. A `warnings` filter or the `-W` option therefore has no effect on
+them. A message that repeats is also written out every time, where the warnings
+machinery would have shown it once. Use `set_log_level` to control them.
+
 The records go to `stderr`, which leaves `stdout` free for your program's own
 output. That matters for anything speaking a protocol over `stdout`, such as an
 MCP stdio server. Pass `osw.enable_logging(stream=...)` to send them elsewhere.

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -64,6 +64,49 @@ Credentials are resolved from the environment variables `OSW_USERNAME` /
 credentials file, or via an interactive prompt - and are held in memory
 only, never written to disk; see [Authentication](api/auth.md).
 
+## Logging
+
+osw reports what it is doing through the standard `logging` module, on the
+`osw` logger, at INFO by default:
+
+```python
+import osw
+
+osw.set_log_level("WARNING")  # see less
+osw.set_log_level("DEBUG")    # see more
+osw.disable_logging()         # detach the handler osw attached
+```
+
+Set `OSW_LOG_LEVEL` to a level name, a level number, or `OFF` to choose the
+level before the package is imported. `OFF` silences osw everywhere, including
+in your own handlers.
+
+### Collecting osw's records in your application
+
+Configure logging the way you normally would and osw's records arrive there,
+once:
+
+```python
+import logging
+import osw
+
+logging.basicConfig(level=logging.INFO, filename="app.log")
+```
+
+The `osw` logger propagates at all times, so the records reach your handlers
+whatever else happens. osw's own handler notices that something above it is
+listening, detaches itself so nothing is written twice, and gives back the
+level it had picked, so your level applies from then on. It makes no difference
+whether you configure logging before or after importing osw.
+
+A level you asked for is kept across that hand-over, so `set_log_level("DEBUG")`
+or `OSW_LOG_LEVEL=DEBUG` is how you pull osw's debug records into an aggregated
+setup while the rest of your application stays quieter.
+
+One case osw cannot detect is a handler added to the `osw` logger itself, since
+that is indistinguishable from one of its own. Call `disable_logging()` first if
+you do that.
+
 ## Examples and tutorials
 
 - Runnable scripts in

--- a/docs/get-started.md
+++ b/docs/get-started.md
@@ -117,6 +117,16 @@ One case osw cannot detect is a handler added to the `osw` logger itself, since
 that is indistinguishable from one of its own. Call `disable_logging()` first if
 you do that.
 
+### Output from parallel batches
+
+Several osw calls process their input in parallel. What such a task prints, as
+opposed to logs, is collected while the batch runs and replayed afterwards, so
+that concurrent writing cannot garble the progress bar. That text arrives on the
+`osw.parallel.output` logger, one record per line, at INFO. Give that logger its
+own level or handler to keep the output of third-party code apart from osw's own
+records. Most osw calls replay it only when you pass `debug=True`; `copy_pages`
+always replays.
+
 ## Examples and tutorials
 
 - Runnable scripts in

--- a/src/osw/__init__.py
+++ b/src/osw/__init__.py
@@ -1,3 +1,6 @@
+import logging
+import os
+import sys
 from importlib.metadata import PackageNotFoundError, version  # pragma: no cover
 
 try:
@@ -8,3 +11,114 @@ except PackageNotFoundError:  # pragma: no cover
     __version__ = "unknown"
 finally:
     del version, PackageNotFoundError
+
+LOG_LEVEL_ENV_VAR = "OSW_LOG_LEVEL"
+"""Name of the environment variable read for the initial log level. Accepts a
+level name, a level number, or 'OFF' to start silent."""
+DEFAULT_LOG_LEVEL = logging.INFO
+"""Level the osw logger starts at when the environment variable is unset"""
+LOG_FORMAT = "[%(levelname)s] %(name)s: %(message)s"
+OFF = logging.CRITICAL + 1
+"""Level above every real record, so setting it silences the logger"""
+
+_DEFAULT_HANDLER_NAME = "osw-default"
+_logger = logging.getLogger(__name__)
+
+
+def _parse_level(value: str) -> int:
+    """Turns the environment variable into a level, tolerating junk
+
+    Parameters
+    ----------
+    value
+        a level name such as 'DEBUG', a level number such as '10', or 'OFF'
+
+    Returns
+    -------
+        the level, or DEFAULT_LOG_LEVEL if the value names none
+    """
+    cleaned = value.strip().upper()
+    if cleaned in ("OFF", "NONE", "SILENT"):
+        return OFF
+    if cleaned.isdigit():
+        return int(cleaned)
+    # getLevelName maps an unknown name to the string 'Level %s', not to a number
+    level = logging.getLevelName(cleaned)
+    if isinstance(level, int):
+        return level
+    return DEFAULT_LOG_LEVEL
+
+
+def enable_logging(level=None, stream=None) -> logging.Handler:
+    """Attaches the default handler to the osw logger
+
+    Called once on import, so osw reports what it is doing without the calling
+    code configuring anything. Call it again to restore the handler after
+    disable_logging(), or to send the records to another stream.
+
+    Parameters
+    ----------
+    level
+        a level name or number. Defaults to the environment variable, then to
+        DEFAULT_LOG_LEVEL.
+    stream
+        where to write. Defaults to sys.stdout, which is where the print calls
+        this replaced used to go.
+
+    Returns
+    -------
+        the attached handler
+    """
+    if level is None:
+        level = _parse_level(os.environ.get(LOG_LEVEL_ENV_VAR, ""))
+    disable_logging()
+    handler = logging.StreamHandler(sys.stdout if stream is None else stream)
+    handler.setFormatter(logging.Formatter(LOG_FORMAT))
+    handler.set_name(_DEFAULT_HANDLER_NAME)
+    _logger.addHandler(handler)
+    _logger.setLevel(level)
+    # the records are handled here, so passing them to the root logger as well
+    # would print everything twice for anyone who called basicConfig()
+    _logger.propagate = False
+    return handler
+
+
+def disable_logging():
+    """Removes the default handler, leaving osw silent
+
+    Only the handler osw attached itself is removed, so a handler the calling
+    code added to the 'osw' logger keeps receiving records. Records propagate
+    to the root logger again, which is what a library is normally expected to
+    do, and lets the calling code take over with basicConfig().
+    """
+    for handler in list(_logger.handlers):
+        if handler.get_name() == _DEFAULT_HANDLER_NAME:
+            _logger.removeHandler(handler)
+            handler.close()
+    _logger.propagate = True
+
+
+def set_log_level(level):
+    """Sets how much osw reports
+
+    Parameters
+    ----------
+    level
+        a level name or number, e.g. 'DEBUG', 'WARNING', or logging.WARNING.
+        Pass osw.OFF to silence osw without detaching the handler.
+    """
+    _logger.setLevel(level)
+
+
+enable_logging()
+
+if os.environ.get(LOG_LEVEL_ENV_VAR) is None:
+    # once per interpreter, since this module is only imported once. Sent
+    # through the logger itself, so it disappears with everything else as soon
+    # as the level is raised or the environment variable is set.
+    _logger.info(
+        "osw logs at %s. Use osw.set_log_level('WARNING') to see less, "
+        "osw.disable_logging() to switch it off, or set %s=OFF before import.",
+        logging.getLevelName(_logger.level),
+        LOG_LEVEL_ENV_VAR,
+    )

--- a/src/osw/__init__.py
+++ b/src/osw/__init__.py
@@ -23,6 +23,9 @@ OFF = logging.CRITICAL + 1
 
 _DEFAULT_HANDLER_NAME = "osw-default"
 _logger = logging.getLogger(__name__)
+_level_is_ours = False
+"""Whether the level on the osw logger is the one osw picked for itself. A
+level the calling code asked for is left alone when osw hands over."""
 
 
 def _parse_level(value: str) -> int:
@@ -49,12 +52,80 @@ def _parse_level(value: str) -> int:
     return DEFAULT_LOG_LEVEL
 
 
-def enable_logging(level=None, stream=None) -> logging.Handler:
-    """Attaches the default handler to the osw logger
+def _application_handles_records() -> bool:
+    """Whether the calling code already has somewhere for osw's records to go
 
-    Called once on import, so osw reports what it is doing without the calling
-    code configuring anything. Call it again to restore the handler after
-    disable_logging(), or to send the records to another stream.
+    Walks what logging.Logger.callHandlers walks above the osw logger. Any
+    handler found up there belongs to the calling application, so osw writing
+    its own copy would only duplicate what that handler already reports.
+    """
+    if not _logger.propagate:
+        # something is deliberately holding the records at the osw logger,
+        # parallelize while it captures a batch among them
+        return False
+    current = _logger.parent
+    while current:
+        if current.handlers:
+            return True
+        if not current.propagate:
+            return False
+        current = current.parent
+    return False
+
+
+class _DefaultHandler(logging.StreamHandler):
+    """The handler osw attaches while nothing else is listening
+
+    Steps aside the first time it finds that the calling application has
+    configured logging of its own. The check belongs here rather than at import
+    time because a script normally imports osw before it calls basicConfig().
+    """
+
+    def emit(self, record: logging.LogRecord):
+        if _application_handles_records():
+            _hand_over()
+            return
+        super().emit(record)
+
+
+def _detach():
+    """Removes the handler osw attached, leaving any other one in place
+
+    Rebinds the list instead of calling removeHandler, because this also runs
+    from inside the handler's own emit, where callHandlers is iterating that
+    very list.
+    """
+    detached = [h for h in _logger.handlers if h.get_name() == _DEFAULT_HANDLER_NAME]
+    _logger.handlers = [h for h in _logger.handlers if h not in detached]
+    for handler in detached:
+        handler.close()
+
+
+def _hand_over():
+    """Gives the application's own logging setup sole charge of osw's records
+
+    Drops osw's handler so nothing is written twice, and drops the level osw
+    picked so the application's level applies. A level the calling code asked
+    for, through set_log_level, enable_logging or the environment variable, is
+    kept, since that is how one asks for osw's DEBUG records in an aggregated
+    setup.
+    """
+    global _level_is_ours
+    _detach()
+    if _level_is_ours:
+        _logger.setLevel(logging.NOTSET)
+        _level_is_ours = False
+
+
+def enable_logging(level=None, stream=None) -> logging.Handler:
+    """Attaches osw's own handler to the osw logger
+
+    Called on import when nothing else handles the records, so osw reports what
+    it is doing without the calling code configuring anything. Call it again to
+    take the output back after disable_logging(), or to send it elsewhere.
+
+    The handler detaches itself as soon as the calling application configures
+    logging, so records are never written twice.
 
     Parameters
     ----------
@@ -69,56 +140,79 @@ def enable_logging(level=None, stream=None) -> logging.Handler:
     -------
         the attached handler
     """
+    global _level_is_ours
+    asked_for = level is not None or LOG_LEVEL_ENV_VAR in os.environ
     if level is None:
         level = _parse_level(os.environ.get(LOG_LEVEL_ENV_VAR, ""))
-    disable_logging()
-    handler = logging.StreamHandler(sys.stdout if stream is None else stream)
+    _detach()
+    handler = _DefaultHandler(sys.stdout if stream is None else stream)
     handler.setFormatter(logging.Formatter(LOG_FORMAT))
     handler.set_name(_DEFAULT_HANDLER_NAME)
     _logger.addHandler(handler)
     _logger.setLevel(level)
-    # the records are handled here, so passing them to the root logger as well
-    # would print everything twice for anyone who called basicConfig()
-    _logger.propagate = False
+    _level_is_ours = not asked_for
     return handler
 
 
 def disable_logging():
-    """Removes the default handler, leaving osw silent
+    """Hands the osw logger over to the calling application
 
-    Only the handler osw attached itself is removed, so a handler the calling
-    code added to the 'osw' logger keeps receiving records. Records propagate
-    to the root logger again, which is what a library is normally expected to
-    do, and lets the calling code take over with basicConfig().
+    Removes the handler osw attached and the level it picked, so the records
+    follow whatever the application configured, on the 'osw' logger or on the
+    root logger above it. A handler the calling code added to the 'osw' logger
+    is left in place.
+
+    Not needed in order to aggregate osw's records. They propagate to the root
+    logger at all times, and osw's own handler steps aside by itself once
+    anything else is listening. Call this to be explicit about it, or when a
+    handler was added to the 'osw' logger directly, which osw cannot tell apart
+    from one of its own callers.
     """
-    for handler in list(_logger.handlers):
-        if handler.get_name() == _DEFAULT_HANDLER_NAME:
-            _logger.removeHandler(handler)
-            handler.close()
-    _logger.propagate = True
+    global _level_is_ours
+    _detach()
+    _logger.setLevel(logging.NOTSET)
+    _level_is_ours = False
 
 
 def set_log_level(level):
     """Sets how much osw reports
 
+    The level survives a hand-over to the application's own logging setup, so
+    this is also how to ask for osw's DEBUG records in an aggregated setup.
+
     Parameters
     ----------
     level
         a level name or number, e.g. 'DEBUG', 'WARNING', or logging.WARNING.
-        Pass osw.OFF to silence osw without detaching the handler.
+        Pass osw.OFF to silence osw everywhere, its own handler and the
+        application's alike.
     """
+    global _level_is_ours
     _logger.setLevel(level)
+    _level_is_ours = False
 
 
-enable_logging()
+def _configure_on_import():
+    """Sets logging up the way an interpreter that configured none needs it"""
+    if _application_handles_records():
+        # logging was configured before osw was imported, so the records
+        # already have somewhere to go and only the level is osw's to set
+        if LOG_LEVEL_ENV_VAR in os.environ:
+            set_log_level(_parse_level(os.environ[LOG_LEVEL_ENV_VAR]))
+        return
+    enable_logging()
+    if LOG_LEVEL_ENV_VAR not in os.environ:
+        # once per interpreter, since this module is imported once. Sent
+        # through the logger itself, so it disappears with everything else as
+        # soon as the level is raised or the environment variable is set.
+        _logger.info(
+            "osw logs at %s on the 'osw' logger. Use osw.set_log_level"
+            "('WARNING') to see less, osw.disable_logging() to switch it off, "
+            "or set %s=OFF before import. Configuring logging yourself, e.g. "
+            "with logging.basicConfig(), takes the output over automatically.",
+            logging.getLevelName(_logger.level),
+            LOG_LEVEL_ENV_VAR,
+        )
 
-if os.environ.get(LOG_LEVEL_ENV_VAR) is None:
-    # once per interpreter, since this module is only imported once. Sent
-    # through the logger itself, so it disappears with everything else as soon
-    # as the level is raised or the environment variable is set.
-    _logger.info(
-        "osw logs at %s. Use osw.set_log_level('WARNING') to see less, "
-        "osw.disable_logging() to switch it off, or set %s=OFF before import.",
-        logging.getLevelName(_logger.level),
-        LOG_LEVEL_ENV_VAR,
-    )
+
+_configure_on_import()

--- a/src/osw/__init__.py
+++ b/src/osw/__init__.py
@@ -133,8 +133,9 @@ def enable_logging(level=None, stream=None) -> logging.Handler:
         a level name or number. Defaults to the environment variable, then to
         DEFAULT_LOG_LEVEL.
     stream
-        where to write. Defaults to sys.stdout, which is where the print calls
-        this replaced used to go.
+        where to write. Defaults to sys.stderr, so stdout stays free for a
+        program's own output. Anything speaking a protocol over stdout, such as
+        an MCP stdio server, depends on that.
 
     Returns
     -------
@@ -145,7 +146,7 @@ def enable_logging(level=None, stream=None) -> logging.Handler:
     if level is None:
         level = _parse_level(os.environ.get(LOG_LEVEL_ENV_VAR, ""))
     _detach()
-    handler = _DefaultHandler(sys.stdout if stream is None else stream)
+    handler = _DefaultHandler(sys.stderr if stream is None else stream)
     handler.setFormatter(logging.Formatter(LOG_FORMAT))
     handler.set_name(_DEFAULT_HANDLER_NAME)
     _logger.addHandler(handler)

--- a/src/osw/auth.py
+++ b/src/osw/auth.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import getpass
+import logging
 import os
 import warnings
 from enum import Enum
@@ -15,6 +16,8 @@ from opensemantic.v1 import OswBaseModel
 from pydantic.v1 import PrivateAttr
 
 from osw.defaults import paths as default_paths
+
+_logger = logging.getLogger(__name__)
 
 
 def _secret_to_str(v):
@@ -131,7 +134,7 @@ class CredentialManager(OswBaseModel):
                     loaded = _load_credentials(fp, into_store=False)
                     all_creds.update(loaded)
                 except Exception as exc:
-                    print(exc)
+                    _logger.error(f"{exc}")
         return all_creds
 
     def get_credential(self, config: CredentialConfig) -> BaseCredential:
@@ -243,7 +246,7 @@ class CredentialManager(OswBaseModel):
                                     if iri_ == iri:
                                         return True
                             except yaml.YAMLError as exc:
-                                print(exc)
+                                _logger.error(f"{exc}")
         return False
 
     def save_credentials_to_file(
@@ -292,9 +295,9 @@ class CredentialManager(OswBaseModel):
             with open(fp, "w", encoding="utf-8") as stream:
                 yaml.dump(data, stream)
             if file_already_exists:
-                print(f"Credentials file updated at '{fp.resolve()}'.")
+                _logger.info(f"Credentials file updated at '{fp.resolve()}'.")
             else:
-                print(f"Credentials file created at '{fp.resolve()}'.")
+                _logger.info(f"Credentials file created at '{fp.resolve()}'.")
 
 
 CredentialManager.CredentialConfig.update_forward_refs()

--- a/src/osw/controller/database.py
+++ b/src/osw/controller/database.py
@@ -1,3 +1,4 @@
+import logging
 from typing import Optional, Union
 
 from opensemantic.v1 import OswBaseModel
@@ -8,6 +9,8 @@ from sqlalchemy.engine import Engine
 import osw.model.entity as model
 from osw.auth import CredentialManager
 from osw.core import OSW
+
+_logger = logging.getLogger(__name__)
 
 
 class DatabaseController(model.Database):
@@ -130,4 +133,4 @@ class DatabaseController(model.Database):
         with self.engine.connect() as conn:
             result_set = conn.execute(sql_text(sql))
             for r in result_set:
-                print(r)
+                _logger.debug(f"{r}")

--- a/src/osw/controller/file/wiki.py
+++ b/src/osw/controller/file/wiki.py
@@ -1,4 +1,5 @@
 import functools
+import logging
 import os
 from typing import IO, Any, Dict, List, Optional
 
@@ -7,6 +8,8 @@ from osw.controller.file.remote import RemoteFileController
 from osw.core import OSW, model
 from osw.utils.wiki import get_namespace, get_title
 from osw.wtsite import WtSite
+
+_logger = logging.getLogger(__name__)
 
 
 class WikiFileController(model.WikiFile, RemoteFileController):
@@ -70,10 +73,9 @@ class WikiFileController(model.WikiFile, RemoteFileController):
         if web_api_failed:
             # fallback: use direct download
             url = file.imageinfo["url"]
-            print(
-                "Extension FileApi not installed on the server. Fallback: use direct "
-                "download from ",
-                url,
+            _logger.warning(
+                f"Extension FileApi not installed on the server. Fallback: use "
+                f"direct download from {url}"
             )
             response = self.osw.mw_site.connection.get(url, stream=True)
 

--- a/src/osw/controller/page_package.py
+++ b/src/osw/controller/page_package.py
@@ -1,10 +1,10 @@
 import importlib.util
 import json
+import logging
 import re
 import sys
 from pathlib import Path
 from typing import Optional, Union
-from warnings import warn
 
 from opensemantic.v1 import OswBaseModel
 from pydantic.v1 import FilePath
@@ -16,6 +16,8 @@ from osw.model import page_package as package
 from osw.model.page_package import NAMESPACE_CONST_TO_NAMESPACE_MAPPING
 from osw.utils.regex import RegExPatternExtended
 from osw.wtsite import WtPage, WtSite
+
+_logger = logging.getLogger(__name__)
 
 # Definition of constants
 PATTERNS = {
@@ -267,7 +269,7 @@ def find_first_package_dir(
             # expected: not every search path holds every package
             continue
         except ValueError as e:
-            warn(
+            _logger.warning(
                 f"Multiple elements {package_or_script_name} found in "
                 f"{search_path}: {e}"
             )
@@ -697,7 +699,7 @@ class PagePackageController(model.PagePackageMetaData):
                 new_listed_pages = []
                 required_packages = []
                 if script_path is None:
-                    warn(
+                    _logger.warning(
                         f"Package script for {package_to_process} not found in any "
                         f"of the search paths: {search_paths}"
                     )
@@ -711,7 +713,7 @@ class PagePackageController(model.PagePackageMetaData):
                             package_script
                         )
                     except Exception as e:
-                        warn(
+                        _logger.warning(
                             f"Error reading package script for "
                             f"{package_to_process}: {e}"
                         )
@@ -724,7 +726,7 @@ class PagePackageController(model.PagePackageMetaData):
                 new_listed_pages = []
                 required_packages = []
                 if package_dir is None:
-                    warn(
+                    _logger.warning(
                         f"Package info for {package_to_process} not found in any "
                         f"of the search paths: {search_paths}"
                     )
@@ -738,7 +740,7 @@ class PagePackageController(model.PagePackageMetaData):
                             get_required_packages_from_package_info_file(package_info)
                         )
                     except Exception as e:
-                        warn(
+                        _logger.warning(
                             f"Error reading package info for {package_to_process}: {e}"
                         )
             # Check for redundant pages
@@ -812,7 +814,7 @@ class PagePackageController(model.PagePackageMetaData):
         # Report on redundantly listed pages
         for pg in rec_ret["redundant_pages"].keys():
             pks = rec_ret["redundant_pages"][pg]
-            warn(f"Page {pg} is listed in {len(pks)} packages!: {pks}")
+            _logger.warning(f"Page {pg} is listed in {len(pks)} packages!: {pks}")
         # Get all listed pages
         all_listed_pages = []
         for pck in rec_ret["listed_pages"].keys():

--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -384,7 +384,7 @@ class OSW(BaseModel):
 
             page.set_slot_content("jsonschema", schema)
         else:
-            _logger.error("Error: Unsupported entity type")
+            _logger.error("Unsupported entity type")
             return
 
         page.edit()
@@ -421,7 +421,7 @@ class OSW(BaseModel):
         ):
             uuid = schema_unregistration.model_cls.__uuid__
         else:
-            _logger.error("Error: Neither model nor model id provided")
+            _logger.error("Neither model nor model id provided")
 
         entity_title = "Category:" + OSW.get_osw_id(uuid)
         page = self.site.get_page(WtSite.GetPageParam(titles=[entity_title])).pages[0]
@@ -615,7 +615,7 @@ class OSW(BaseModel):
                 0
             ]
             if not page.exists:
-                _logger.error(f"Error: Page {schema_title} does not exist")
+                _logger.error(f"Page {schema_title} does not exist")
                 # the $ref that led here was already rewritten to this file name
                 write_schema_stub(get_model_dir_path(), schema_name)
                 return OSW.FetchSchemaResult(
@@ -637,7 +637,7 @@ class OSW(BaseModel):
                 )
                 schema_str = json.dumps(schema)
         if (schema_str is None) or (schema_str == ""):
-            _logger.warning(f"Warning: Schema slot of {schema_title} is empty")
+            _logger.warning(f"Schema slot of {schema_title} is empty")
             schema_str = "{}"  # empty schema to make reference work
             if fetchSchemaParam.warning_messages is None:
                 fetchSchemaParam.warning_messages = []
@@ -1267,7 +1267,7 @@ class OSW(BaseModel):
                         if not hasattr(model, cls_name):
                             schemas_fetched = False
                             _logger.error(
-                                f"Error: Model {cls_name} not found. Schema {category} "
+                                f"Model {cls_name} not found. Schema {category} "
                                 f"needs to be fetched first."
                             )
             if not schemas_fetched:
@@ -1278,7 +1278,7 @@ class OSW(BaseModel):
                     entity: model.OswBaseModel = param.model_to_use(**jsondata)
 
                 elif len(schemas) == 0:
-                    _logger.error("Error: no schema defined")
+                    _logger.error("no schema defined")
 
                 elif len(schemas) == 1:
                     cls: Type[model.Entity] = getattr(model, schemas[0]["title"])
@@ -1409,7 +1409,7 @@ class OSW(BaseModel):
                     uuid_from_title = get_uuid(title)
                 except ValueError:
                     _logger.error(
-                        f"Error: UUID could not be determined from title: '{title}', "
+                        f"UUID could not be determined from title: '{title}', "
                         f"nor fromjsondata: {jsondata}"
                     )
                     return entity
@@ -1980,7 +1980,7 @@ class OSW(BaseModel):
             if title_ is None:
                 title_ = OSW.get_osw_id(entity_.uuid)
             if namespace_ is None or title_ is None:
-                _logger.error("Error: Unsupported entity type")
+                _logger.error("Unsupported entity type")
                 return
             entity_title = namespace_ + ":" + title_
             page = self.site.get_page(WtSite.GetPageParam(titles=[entity_title])).pages[

--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -384,11 +384,11 @@ class OSW(BaseModel):
 
             page.set_slot_content("jsonschema", schema)
         else:
-            print("Error: Unsupported entity type")
+            _logger.error("Error: Unsupported entity type")
             return
 
         page.edit()
-        print("Entity stored at " + page.get_url())
+        _logger.info("Entity stored at " + page.get_url())
 
     class SchemaUnregistration(BaseModel):
         """dataclass param of register_schema()"""
@@ -421,7 +421,7 @@ class OSW(BaseModel):
         ):
             uuid = schema_unregistration.model_cls.__uuid__
         else:
-            print("Error: Neither model nor model id provided")
+            _logger.error("Error: Neither model nor model id provided")
 
         entity_title = "Category:" + OSW.get_osw_id(uuid)
         page = self.site.get_page(WtSite.GetPageParam(titles=[entity_title])).pages[0]
@@ -607,15 +607,15 @@ class OSW(BaseModel):
             fetchSchemaParam.offline_pages is not None
             and schema_title in fetchSchemaParam.offline_pages
         ):
-            print(f"Fetch {schema_title} from offline pages")
+            _logger.info(f"Fetch {schema_title} from offline pages")
             page = fetchSchemaParam.offline_pages[schema_title]
         else:
-            print(f"Fetch {schema_title} from online pages")
+            _logger.info(f"Fetch {schema_title} from online pages")
             page = self.site.get_page(WtSite.GetPageParam(titles=[schema_title])).pages[
                 0
             ]
             if not page.exists:
-                print(f"Error: Page {schema_title} does not exist")
+                _logger.error(f"Error: Page {schema_title} does not exist")
                 # the $ref that led here was already rewritten to this file name
                 write_schema_stub(get_model_dir_path(), schema_name)
                 return OSW.FetchSchemaResult(
@@ -637,7 +637,7 @@ class OSW(BaseModel):
                 )
                 schema_str = json.dumps(schema)
         if (schema_str is None) or (schema_str == ""):
-            print(f"Warning: Schema slot of {schema_title} is empty")
+            _logger.warning(f"Warning: Schema slot of {schema_title} is empty")
             schema_str = "{}"  # empty schema to make reference work
             if fetchSchemaParam.warning_messages is None:
                 fetchSchemaParam.warning_messages = []
@@ -1027,7 +1027,7 @@ class OSW(BaseModel):
                     # may overlap partially, e.g.
                     # from datetime import date
                     # from datetime import date, datetime
-                    print("Replace import statement:", import_stmt)
+                    _logger.info(f"Replace import statement: {import_stmt}")
                     content = re.sub(
                         r"^" + re.escape(import_stmt) + r"$",
                         "",
@@ -1216,7 +1216,7 @@ class OSW(BaseModel):
             param = entity_title
 
         if param.model_to_use:
-            print(f"Using schema {param.model_to_use.__name__} to create entity")
+            _logger.info(f"Using schema {param.model_to_use.__name__} to create entity")
 
         # store original cache state
         cache_state = self.site.get_cache_enabled()
@@ -1266,7 +1266,7 @@ class OSW(BaseModel):
                                 )
                         if not hasattr(model, cls_name):
                             schemas_fetched = False
-                            print(
+                            _logger.error(
                                 f"Error: Model {cls_name} not found. Schema {category} "
                                 f"needs to be fetched first."
                             )
@@ -1408,7 +1408,7 @@ class OSW(BaseModel):
                 try:
                     uuid_from_title = get_uuid(title)
                 except ValueError:
-                    print(
+                    _logger.error(
                         f"Error: UUID could not be determined from title: '{title}', "
                         f"nor fromjsondata: {jsondata}"
                     )
@@ -1450,7 +1450,7 @@ class OSW(BaseModel):
 
         def set_content(content_to_set: dict) -> None:
             if param.debug:
-                print(f"content_to_set: {content_to_set!s}")
+                _logger.debug(f"content_to_set: {content_to_set!s}")
             for slot_ in content_to_set.keys():
                 page.set_slot_content(slot_, content_to_set[slot_])
 
@@ -1481,7 +1481,7 @@ class OSW(BaseModel):
             page.exists
             and param.policy.overwrite == AddOverwriteClassOptions.keep_existing
         ):
-            print(
+            _logger.warning(
                 f"Entity '{entity_title}' already exists and won't be stored "
                 f"with overwrite set to 'keep existing'!"
             )
@@ -1509,7 +1509,7 @@ class OSW(BaseModel):
         if remote_content["footer"]:
             new_content["footer"] = remote_content["footer"]
         if param.debug:
-            print(f"'remote_content': {remote_content!s}")
+            _logger.debug(f"'remote_content': {remote_content!s}")
         # Get the local content
         # Properties that are not set in the local content will be set to None
         # We want those not to be listed as keys
@@ -1517,7 +1517,7 @@ class OSW(BaseModel):
         if param.remove_empty:
             remove_empty(local_content["jsondata"])
         if param.debug:
-            print(f"'local_content': {local_content!s}")
+            _logger.debug(f"'local_content': {local_content!s}")
         # Apply the overwrite logic
         # a) If there is a key in the remote content that is not in the local
         #    content, we have to keep it
@@ -1530,7 +1530,7 @@ class OSW(BaseModel):
         #     if key not in local_content["jsondata"].keys()
         # }
         if param.debug:
-            print(f"'New content' after 'remote' update: {new_content!s}")
+            _logger.debug(f"'New content' after 'remote' update: {new_content!s}")
         # b) If there is a key in the local content that is not in the remote
         #    content, we have to keep it
         new_content["jsondata"].update({
@@ -1539,7 +1539,7 @@ class OSW(BaseModel):
             if key not in remote_content["jsondata"].keys()
         })
         if param.debug:
-            print(f"'New content' after 'local' update: {new_content!s}")
+            _logger.debug(f"'New content' after 'local' update: {new_content!s}")
         # c) If there is a key in both contents, we have to apply the overwrite
         #    logic
         # todo: include logic for hidden and read_only properties!
@@ -1549,14 +1549,14 @@ class OSW(BaseModel):
             if param.policy.get_overwrite_setting(key) == OverwriteOptions.true
         })
         if param.debug:
-            print(f"'New content' after 'True' update: {new_content!s}")
+            _logger.debug(f"'New content' after 'True' update: {new_content!s}")
         new_content["jsondata"].update({
             key: value
             for (key, value) in remote_content["jsondata"].items()
             if param.policy.get_overwrite_setting(key) == OverwriteOptions.false
         })
         if param.debug:
-            print(f"'New content' after 'False' update: {new_content!s}")
+            _logger.debug(f"'New content' after 'False' update: {new_content!s}")
         new_content["jsondata"].update({
             key: value
             for (key, value) in local_content["jsondata"].items()
@@ -1566,8 +1566,8 @@ class OSW(BaseModel):
             )
         })
         if param.debug:
-            print(f"'New content' after 'only empty' update: {new_content!s}")
-            print(f"'New content' to be stored: {new_content!s}")
+            _logger.debug(f"'New content' after 'only empty' update: {new_content!s}")
+            _logger.debug(f"'New content' to be stored: {new_content!s}")
         set_content(new_content)
         return page  # Guard clause --> exit function
 
@@ -1792,7 +1792,9 @@ class OSW(BaseModel):
                         )
                         generated_schemas[key] = json.loads(schema_str)
                 except Exception as e:
-                    print(f"Schema generation from template failed for {entity_}: {e}")
+                    _logger.error(
+                        f"Schema generation from template failed for {entity_}: {e}"
+                    )
 
                 mode = AggregateGeneratedSchemasParamMode.ROOT_LEVEL
                 # Put generated schema in definitions section,
@@ -1816,16 +1818,16 @@ class OSW(BaseModel):
                 )  # will set page.changed if the content of the page has changed
             if not param.offline and page.changed:
                 if index is None:
-                    print(f"Entity stored at '{page.get_url()}'.")
+                    _logger.info(f"Entity stored at '{page.get_url()}'.")
                 else:
-                    print(
+                    _logger.info(
                         f"({index + 1}/{max_index}) Entity stored at "
                         f"'{page.get_url()}'."
                     )
             created_pages[page.title] = page
 
         sorted_entities = OSW.sort_list_of_entities_by_class(param.entities)
-        print(
+        _logger.info(
             "Entities to be uploaded have been sorted according to their type.\n"
             "If you would like to overwrite existing entities or properties, "
             "pass a StoreEntityParam to store_entity() with "
@@ -1853,7 +1855,7 @@ class OSW(BaseModel):
                     overwrite=param.overwrite,
                 )
                 if param.debug:
-                    print(
+                    _logger.debug(
                         f"Now adding entities of class type '{class_type}' "
                         f"({entity_model.__name__}) to upload list. No class specific"
                         f" overwrite setting found. Using fallback option '"
@@ -1978,7 +1980,7 @@ class OSW(BaseModel):
             if title_ is None:
                 title_ = OSW.get_osw_id(entity_.uuid)
             if namespace_ is None or title_ is None:
-                print("Error: Unsupported entity type")
+                _logger.error("Error: Unsupported entity type")
                 return
             entity_title = namespace_ + ":" + title_
             page = self.site.get_page(WtSite.GetPageParam(titles=[entity_title])).pages[
@@ -1987,9 +1989,9 @@ class OSW(BaseModel):
 
             if page.exists:
                 page.delete(comment_)
-                print("Entity deleted: " + page.get_url())
+                _logger.info("Entity deleted: " + page.get_url())
             else:
-                print(f"Entity '{entity_title}' does not exist!")
+                _logger.warning(f"Entity '{entity_title}' does not exist!")
 
         if entity.parallel:
             _ = parallelize(

--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -11,7 +11,6 @@ from copy import deepcopy
 from enum import Enum
 from typing import Any, Dict, List, Optional, Type, Union, overload
 from uuid import UUID, uuid4
-from warnings import warn
 
 import black
 import datamodel_code_generator
@@ -286,7 +285,7 @@ class OSW(BaseModel):
                         f"as the class does not define a field 'type'."
                     )
                 if exclude_typeless:
-                    warn(
+                    _logger.warning(
                         f"Skipping instance '{entity}' of class '{name}' as the class "
                         f"does not define a field 'type'."
                     )

--- a/src/osw/data/import_utility.py
+++ b/src/osw/data/import_utility.py
@@ -1,5 +1,6 @@
 import copy
 import inspect
+import logging
 import re
 import uuid as uuid_module
 import warnings
@@ -20,6 +21,8 @@ from osw.model import entity as model
 from osw.utils.regex import MatchResult, RegExPatternExtended
 from osw.utils.regex_pattern import REGEX_PATTERN_LIB
 from osw.wtsite import WtPage, WtSite
+
+_logger = logging.getLogger(__name__)
 
 # Constants
 ENABLE_SORTING = True
@@ -206,7 +209,7 @@ def transform_attributes_and_merge(
                         del ent_as_dict[other_k]
                     del ent[other_k]
                     del_keys.append(other_k)
-    print(f"Merge operation complete. Deleted keys: {del_keys}")
+    _logger.info(f"Merge operation complete. Deleted keys: {del_keys}")
     return {"entities": ent, "entities_as_dict": ent_as_dict}
 
 
@@ -805,7 +808,7 @@ def get_entities_from_osw(
     wtsite_obj = osw_obj.site
     entities_from_osw = []
     if debug:
-        print(f"Searching for instances of {category_to_search} in OSW...")
+        _logger.debug(f"Searching for instances of {category_to_search} in OSW...")
     entities = wtsite_obj.semantic_search(
         query=(
             wt.SearchParam(

--- a/src/osw/data/import_utility.py
+++ b/src/osw/data/import_utility.py
@@ -3,7 +3,6 @@ import inspect
 import logging
 import re
 import uuid as uuid_module
-import warnings
 from pathlib import Path
 from typing import Any, Callable, Dict, List, Optional, Type, Union
 
@@ -412,9 +411,8 @@ def jsonpath_search_and_return_list(
             # Search in a dramatically reduced number of entries
             result = jp_parse.find(search_tar[str(cls_type)])
         except Exception as e:
-            warnings.warn(
-                f"jsonpath_search_and_return_list() threw and exception:\n{e!s}",
-                stacklevel=2,
+            _logger.warning(
+                f"jsonpath_search_and_return_list() threw and exception:\n{e!s}"
             )
             result = jp_parse.find(search_tar)
     else:
@@ -434,10 +432,9 @@ def jsonpath_search_and_return_list(
                     list_.append(res.value[val_key])
 
     if len(list_) == 0 and warn:
-        warnings.warn(
+        _logger.warning(
             f"jsonpath_search_and_return_list() did not find any "
-            f"results for the jsonpath string '{jp_str}'",
-            stacklevel=3,
+            f"results for the jsonpath string '{jp_str}'"
         )
     return list(set(flatten_list(list_)))
 

--- a/src/osw/defaults.py
+++ b/src/osw/defaults.py
@@ -1,10 +1,13 @@
 from __future__ import annotations
 
+import logging
 import re
 from pathlib import Path
 from typing import List, Union
 
 from pydantic.v1 import BaseModel, PrivateAttr, validator
+
+_logger = logging.getLogger(__name__)
 
 PACKAGE_ROOT_PATH = Path(__file__).parents[2]
 SRC_PATH = PACKAGE_ROOT_PATH / "src"
@@ -125,7 +128,7 @@ class Paths(Defaults):
                     new_rel_path = new_val / old_rel_path
                     setattr(self, attr_name, new_rel_path)
                     cls_name = type(self).__name__
-                    print(
+                    _logger.info(
                         f"Following the setting of {cls_name}.{set_attr}, "
                         f"{cls_name}.{attr_name} was updated to {new_rel_path}."
                     )

--- a/src/osw/express.py
+++ b/src/osw/express.py
@@ -11,6 +11,7 @@ directory, which is based on the current working directory
 """
 
 import importlib.util
+import logging
 import os
 import re
 from enum import Enum
@@ -46,6 +47,8 @@ from osw.defaults import params as default_params
 from osw.defaults import paths as default_paths
 from osw.utils.wiki import namespace_from_full_title, title_from_full_title
 from osw.wtsite import WtSite
+
+_logger = logging.getLogger(__name__)
 
 
 class OswExpress(OSW):
@@ -127,7 +130,7 @@ class OswExpress(OSW):
             if not isinstance(cred_filepath, Path):
                 cred_filepath = Path(cred_filepath)
             if not cred_filepath.is_file():
-                print(
+                _logger.warning(
                     f"Credential file '{cred_filepath}' does not exist and will "
                     "be ignored. Credentials are taken from the environment "
                     "variables OSW_USERNAME/OSW_PASSWORD or an interactive "
@@ -146,7 +149,7 @@ class OswExpress(OSW):
             response = requests.get(url)  # noqa: S113 reachability probe, TODO add timeout
             if response.status_code == 200:
                 # Domain is reachable
-                print(f"Connecting to '{domain}'...")
+                _logger.info(f"Connecting to '{domain}'...")
             else:
                 raise ConnectionError(
                     f"Could not connect to '{domain}'. Response: {response.status_code}"
@@ -157,7 +160,7 @@ class OswExpress(OSW):
         super().__init__(**{"site": site, "domain": domain})
         self.cred_mngr = cred_mngr
         self.cred_filepath = cred_filepath
-        print(f"Connected to '{domain}'.")
+        _logger.info(f"Connected to '{domain}'.")
 
     def __enter__(self):
         """Return self when entering the context manager."""

--- a/src/osw/express.py
+++ b/src/osw/express.py
@@ -19,7 +19,6 @@ from io import TextIOWrapper
 from pathlib import Path
 from typing import overload
 from uuid import uuid4
-from warnings import warn
 
 import requests
 from opensemantic.v1 import OswBaseModel
@@ -451,7 +450,7 @@ def build_target_fn(
     if mode == FilenameMode.osw_id:
         return osw_id_fn
     if not name:
-        warn(
+        _logger.warning(
             f"No name is stored for '{osw_id_fn}', falling back to the OSW-ID as "
             f"the file name."
         )
@@ -1001,7 +1000,7 @@ def import_with_fallback(
     except Exception as e:
         if dependencies is None:
             dependencies = {}
-            warn(
+            _logger.warning(
                 "No 'dependencies' were passed to the function "
                 "import_with_fallback()! Trying to derive them from 'to_import'."
             )
@@ -1018,7 +1017,7 @@ def import_with_fallback(
                 "No 'dependencies' were passed to the function import_with_fallback() "
                 "and could not be derived from 'to_import'!"
             )
-        warn(
+        _logger.warning(
             f"An exception occurred while loading the module dependencies: \n"
             f'"{e}"\n'
             "A connection to an OSW instance, to fetch the dependencies from, "

--- a/src/osw/ontology.py
+++ b/src/osw/ontology.py
@@ -609,10 +609,10 @@ class OntologyImporter(OswBaseModel):
                             "de",
                         ]:
                             # ToDo: Support all/more languages
-                            _logger.warning((
-                                "Warning: remove value with unsupported language: ",
-                                f"{node[key]['lang']}",
-                            ))
+                            _logger.warning(
+                                "remove value with unsupported language: "
+                                f"{node[key]['lang']}"
+                            )
                             del node[key]
                             continue
                     elif isinstance(node[key], list):
@@ -626,22 +626,19 @@ class OntologyImporter(OswBaseModel):
                                     "lang"
                                 ] not in ["en", "de"]:
                                     # ToDo: Support all/more languages
-                                    _logger.warning((
-                                        "Warning: remove value with unsupported language: ",
-                                        f"{node[key][i]['lang']}",
-                                    ))
+                                    _logger.warning(
+                                        "remove value with unsupported language: "
+                                        f"{node[key][i]['lang']}"
+                                    )
                                     del node[key][i]
                                     continue
                             else:
                                 _logger.warning(
-                                    "Warning: remove invalide multilang value: "
-                                    f"{node[key][i]}"
+                                    f"remove invalide multilang value: {node[key][i]}"
                                 )
                                 del node[key][i]
                     else:
-                        _logger.warning(
-                            f"Warning: remove invalide multilang value: {node[key]}"
-                        )
+                        _logger.warning(f"remove invalide multilang value: {node[key]}")
                         del node[key]
             for key in ps.ensure_array:
                 if key in node and not isinstance(node[key], list):
@@ -823,7 +820,7 @@ class OntologyImporter(OswBaseModel):
                 )
                 text += f"\n {new_iri}|{smw_import_type}"
             else:
-                _logger.error("Error: Entity has not iri/uri property")
+                _logger.error("Entity has not iri/uri property")
 
         import_page.set_slot_content("main", text)
         import_page.edit("import ontology")
@@ -887,7 +884,7 @@ class OntologyImporter(OswBaseModel):
                 if o.prefix == prefix or o.prefix_name == prefix:
                     onto = o
             if onto is None:
-                _logger.error(f"Error: No ontology defined for prefix {prefix}")
+                _logger.error(f"No ontology defined for prefix {prefix}")
             else:
                 if not dry_run:
                     self._store_ontology(

--- a/src/osw/ontology.py
+++ b/src/osw/ontology.py
@@ -1,4 +1,5 @@
 import json
+import logging
 import os
 import re
 import uuid
@@ -13,6 +14,8 @@ from osw.core import OSW, model
 from osw.utils.strings import camel_case, pascal_case
 from osw.utils.wiki import get_namespace
 from osw.wtsite import WtSite
+
+_logger = logging.getLogger(__name__)
 
 
 class ParserSettings(OswBaseModel):
@@ -194,7 +197,7 @@ class OntologyImporter(OswBaseModel):
 
         # load the imported ontologies and merge them into the main graph
         for onto in ontologies_to_import:
-            print(f"Importing {onto}")
+            _logger.info(f"Importing {onto}")
             _rdf_graph = OntologyImporter._recursive_ontology_import(
                 onto,
                 format_=format_,
@@ -236,7 +239,7 @@ class OntologyImporter(OswBaseModel):
                     and iri in self.import_config.import_mapping
                 ):
                     iri = self.import_config.import_mapping[iri]
-                print(f"Importing {iri}")
+                _logger.info(f"Importing {iri}")
                 rdf_graph.parse(iri)
 
         # load the ontology file
@@ -606,7 +609,7 @@ class OntologyImporter(OswBaseModel):
                             "de",
                         ]:
                             # ToDo: Support all/more languages
-                            print((
+                            _logger.warning((
                                 "Warning: remove value with unsupported language: ",
                                 f"{node[key]['lang']}",
                             ))
@@ -623,20 +626,22 @@ class OntologyImporter(OswBaseModel):
                                     "lang"
                                 ] not in ["en", "de"]:
                                     # ToDo: Support all/more languages
-                                    print((
+                                    _logger.warning((
                                         "Warning: remove value with unsupported language: ",
                                         f"{node[key][i]['lang']}",
                                     ))
                                     del node[key][i]
                                     continue
                             else:
-                                print(
+                                _logger.warning(
                                     "Warning: remove invalide multilang value: "
                                     f"{node[key][i]}"
                                 )
                                 del node[key][i]
                     else:
-                        print(f"Warning: remove invalide multilang value: {node[key]}")
+                        _logger.warning(
+                            f"Warning: remove invalide multilang value: {node[key]}"
+                        )
                         del node[key]
             for key in ps.ensure_array:
                 if key in node and not isinstance(node[key], list):
@@ -675,7 +680,7 @@ class OntologyImporter(OswBaseModel):
                 elif "label" in node:
                     node["name"] = node["label"][0]["text"]
                 else:
-                    print("No label: ", node["iri"])
+                    _logger.warning(f"No label: {node['iri']}")
                     # node["name"] = node["iri"].split("/")[-1].split("#")[-1]
                     # warning(f"Fallback to name from iri: {node['name']}")
                 if "name" in node:
@@ -774,8 +779,8 @@ class OntologyImporter(OswBaseModel):
 
                     except Exception as ex:
                         # print the validation error
-                        print("Exception while generating entity with ", node)
-                        print(ex)
+                        _logger.error(f"Exception while generating entity with {node}")
+                        _logger.error(ex)
 
                     if e:
                         self._entities.append(e)
@@ -818,7 +823,7 @@ class OntologyImporter(OswBaseModel):
                 )
                 text += f"\n {new_iri}|{smw_import_type}"
             else:
-                print("Error: Entity has not iri/uri property")
+                _logger.error("Error: Entity has not iri/uri property")
 
         import_page.set_slot_content("main", text)
         import_page.edit("import ontology")
@@ -854,7 +859,7 @@ class OntologyImporter(OswBaseModel):
             dry_run = param.dryrun
             ontologies = param.ontologies
 
-        print(f"{len(entities)} classes to import")
+        _logger.info(f"{len(entities)} classes to import")
         prefix_dict = {}
         for e in entities:
             if "//" in e.iri:
@@ -882,7 +887,7 @@ class OntologyImporter(OswBaseModel):
                 if o.prefix == prefix or o.prefix_name == prefix:
                     onto = o
             if onto is None:
-                print(f"Error: No ontology defined for prefix {prefix}")
+                _logger.error(f"Error: No ontology defined for prefix {prefix}")
             else:
                 if not dry_run:
                     self._store_ontology(

--- a/src/osw/sparql_client_smw.py
+++ b/src/osw/sparql_client_smw.py
@@ -1,7 +1,10 @@
 # from quantities
 import getpass
+import logging
 
 from SPARQLWrapper import BASIC, JSON, POST, SPARQLWrapper
+
+_logger = logging.getLogger(__name__)
 
 
 class SmwSparqlClient:
@@ -166,14 +169,16 @@ class SmwSparqlClient:
         for key in self.encoding_dict.keys():
             query = query.replace(key, self.encoding_dict[key])
         if debug:
-            print(query)
+            _logger.debug(query)
         # Select distinct ?p ?o where
         #  {<http://dbpedia.org/resource/Amount_of_substance> ?p ?o} LIMIT 100
         triples = self.sparqlQuery(query)
         # print(triples)
         tdict = {}
         if debug:
-            print("{} triplets found".format(len(triples["results"]["bindings"])))
+            _logger.debug(
+                "{} triplets found".format(len(triples["results"]["bindings"]))
+            )
         for t in triples["results"]["bindings"]:
             if tsubject == "":
                 s = t["subject"]["value"]

--- a/src/osw/utils/util.py
+++ b/src/osw/utils/util.py
@@ -16,6 +16,8 @@ import dask
 from dask.diagnostics import ProgressBar
 from tqdm.asyncio import tqdm
 
+_logger = logging.getLogger(__name__)
+
 # dask.config.set(scheduler="threads")
 # with stdio_proxy.redirect_stdout(sys.stdout):
 # "processes" scheduler leads to no messages ending up in the buffer / no flushing
@@ -250,7 +252,7 @@ def redirect_print_explicitly(
                 buffer = MessageBuffer()
                 for line in lines:
                     print(line, file=buffer)
-                print("Printing buffered messages.")
+                _logger.debug("Printing buffered messages.")
                 buffer.flush()
             else:
                 for line in lines:
@@ -456,7 +458,9 @@ def parallelize(
             )
             for index, item in enumerate(items)
         ]
-        print(f"Performing parallel execution of {func.__name__} ({len(tasks)} tasks).")
+        _logger.info(
+            f"Performing parallel execution of {func.__name__} ({len(tasks)} tasks)."
+        )
         if return_exceptions:
             # tqdm.gather() re-raises the first exception (it has no
             # return_exceptions kwarg), which would abandon the remaining
@@ -570,7 +574,7 @@ def async_parallelize(func: Callable, iterable: Iterable, **kwargs):
                 dask.delayed(redirect_print_explicitly(func_, msg_buf))(item, **kwargs_)
                 for item in iterable_
             ]
-            print(
+            _logger.info(
                 f"Performing parallel execution of {func.__name__} "
                 f"({len(tasks)} tasks)."
             )

--- a/src/osw/utils/util.py
+++ b/src/osw/utils/util.py
@@ -1,5 +1,6 @@
 import asyncio
 import functools
+import logging
 import sys
 import threading
 from asyncio import Queue
@@ -309,18 +310,85 @@ class ThreadRoutedStdout:
         return getattr(self.stream, name)
 
 
+class ThreadRoutedLogHandler(logging.Handler):
+    """A log handler that routes each worker thread's records to its own buffer
+
+    The counterpart of ThreadRoutedStdout for the modules that log rather than
+    print. Installed on the 'osw' logger for the duration of a parallelize()
+    call, in place of the handlers a record would otherwise reach. Threads that
+    have not registered a buffer, the calling thread among them, are forwarded
+    to those handlers unchanged.
+
+    Routing has to happen at the handler, not at a filter on the 'osw' logger. A
+    logger's filters only run for records logged on that logger itself, so they
+    would never see the records from osw.wtsite and the other child loggers.
+    """
+
+    def __init__(self, handlers: List[logging.Handler]):
+        super().__init__()
+        self.handlers = handlers
+        self._local = threading.local()
+
+    def register(self) -> List[logging.LogRecord]:
+        """Gives the calling thread its own buffer and returns it"""
+        buffer = []
+        self._local.buffer = buffer
+        return buffer
+
+    def unregister(self):
+        """Sends the calling thread's records back to the wrapped handlers"""
+        self._local.buffer = None
+
+    def emit(self, record: logging.LogRecord):
+        buffer = getattr(self._local, "buffer", None)
+        if buffer is None:
+            self.replay(record)
+            return
+        buffer.append(record)
+
+    def replay(self, record: logging.LogRecord):
+        """Passes a record on to the handlers this one stands in for"""
+        for handler in self.handlers:
+            if record.levelno >= handler.level:
+                handler.handle(record)
+
+
+def handler_chain(logger: logging.Logger) -> List[logging.Handler]:
+    """The handlers a record logged on logger reaches, ancestors included
+
+    Mirrors what logging.Logger.callHandlers walks, so that replacing the
+    handlers of one logger can stand in for the whole chain.
+    """
+    handlers = []
+    current = logger
+    while current:
+        handlers.extend(current.handlers)
+        if not current.propagate:
+            break
+        current = current.parent
+    return handlers
+
+
 def capture_output(
-    call: Callable, stdout: ThreadRoutedStdout, sink: List[str], index: int
+    call: Callable,
+    stdout: ThreadRoutedStdout,
+    log_handler: ThreadRoutedLogHandler,
+    printed: List[str],
+    logged: List[List[logging.LogRecord]],
+    index: int,
 ) -> Callable:
-    """Wraps call so that what it prints ends up in sink[index] instead of stdout"""
+    """Wraps call so what it prints and logs ends up in the slot at index"""
 
     def wrapper():
         buffer = stdout.register()
+        records = log_handler.register()
         try:
             return call()
         finally:
             stdout.unregister()
-            sink[index] = "".join(buffer)
+            log_handler.unregister()
+            printed[index] = "".join(buffer)
+            logged[index] = records
 
     return wrapper
 
@@ -361,7 +429,12 @@ def parallelize(
     # One slot per item, so the collected output can be replayed in input order
     # even though the tasks finish in whatever order they finish.
     outputs = [""] * len(items)
+    records: List[List[logging.LogRecord]] = [[] for _ in items]
     stdout = ThreadRoutedStdout(sys.stdout)
+    osw_logger = logging.getLogger("osw")
+    log_handler = ThreadRoutedLogHandler(handler_chain(osw_logger))
+    saved_handlers = osw_logger.handlers
+    saved_propagate = osw_logger.propagate
 
     # run func concurrently with each item in iterable using asyncio
     async def _run_tasks():
@@ -373,7 +446,12 @@ def parallelize(
             loop.run_in_executor(
                 None,
                 capture_output(
-                    functools.partial(func, item, **kwargs), stdout, outputs, index
+                    functools.partial(func, item, **kwargs),
+                    stdout,
+                    log_handler,
+                    outputs,
+                    records,
+                    index,
                 ),
             )
             for index, item in enumerate(items)
@@ -396,6 +474,10 @@ def parallelize(
         return await gather(*tasks)
 
     sys.stdout = stdout
+    # standing in for the whole chain, so records from the osw.* child loggers
+    # are routed too rather than propagating past this handler to the originals
+    osw_logger.handlers = [log_handler]
+    osw_logger.propagate = False
     try:
         # Check if we are already in an event loop, e.g. in a Jupyter notebook
         try:
@@ -414,12 +496,16 @@ def parallelize(
             results = asyncio.run(_run_tasks())
     finally:
         sys.stdout = stdout.stream
+        osw_logger.handlers = saved_handlers
+        osw_logger.propagate = saved_propagate
         if flush_at_end:
             # in the finally block, so a failed batch still reports what its
             # tasks had to say
-            for output in outputs:
+            for output, task_records in zip(outputs, records):
                 if output:
                     print(output, end="")
+                for record in task_records:
+                    log_handler.replay(record)
 
     return results
 

--- a/src/osw/utils/util.py
+++ b/src/osw/utils/util.py
@@ -18,6 +18,12 @@ from tqdm.asyncio import tqdm
 
 _logger = logging.getLogger(__name__)
 
+# What a parallelized task printed rather than logged. It gets a name of its own
+# so a caller can filter the output of foreign code apart from osw's own records,
+# and so the name describes what the records carry rather than which function
+# replayed them.
+TASK_OUTPUT_LOGGER = "osw.parallel.output"
+
 # dask.config.set(scheduler="threads")
 # with stdio_proxy.redirect_stdout(sys.stdout):
 # "processes" scheduler leads to no messages ending up in the buffer / no flushing
@@ -413,11 +419,14 @@ def parallelize(
         The iterable, who's items are to be passed as singles to the function.
     flush_at_end:
         If True, what the tasks print and log is written out in the order of
-        ``iterable`` once the batch has finished. If False, it is discarded,
-        except for log records at WARNING and above. Those report a problem
-        rather than progress, so they are written out either way. Either way
-        the output is captured while the tasks run, so that concurrent writing
-        cannot garble the progress bar.
+        ``iterable`` once the batch has finished. What a task printed is
+        replayed one line at a time as INFO records on the ``osw.parallel.output``
+        logger, so it reaches the caller's handlers like everything else rather
+        than going straight to stdout. If False, both are discarded, except for
+        log records at WARNING and above. Those report a problem rather than
+        progress, so they are written out either way. Either way the output is
+        captured while the tasks run, so that concurrent writing cannot garble
+        the progress bar.
     progress_bar:
         If True, a progress bar will be displayed.
     return_exceptions:
@@ -506,9 +515,14 @@ def parallelize(
         osw_logger.propagate = saved_propagate
         # in the finally block, so a failed batch still reports what its
         # tasks had to say
+        task_output = logging.getLogger(TASK_OUTPUT_LOGGER)
         for output, task_records in zip(outputs, records):
-            if flush_at_end and output:
-                print(output, end="")
+            if flush_at_end:
+                # One record per line, so each carries its own level and name
+                # instead of one prefix followed by a block of text
+                for line in output.splitlines():
+                    if line:
+                        task_output.info(line)
             for record in task_records:
                 # A warning reports a problem, not progress, so a batch asked
                 # to stay quiet still passes it on. Discarding it would hide

--- a/src/osw/utils/util.py
+++ b/src/osw/utils/util.py
@@ -412,10 +412,12 @@ def parallelize(
     iterable:
         The iterable, who's items are to be passed as singles to the function.
     flush_at_end:
-        If True, what the tasks print is written to stdout in the order of
-        ``iterable`` once the batch has finished. If False, it is discarded.
-        Either way it is captured while the tasks run, so that concurrent
-        printing cannot garble the progress bar.
+        If True, what the tasks print and log is written out in the order of
+        ``iterable`` once the batch has finished. If False, it is discarded,
+        except for log records at WARNING and above. Those report a problem
+        rather than progress, so they are written out either way. Either way
+        the output is captured while the tasks run, so that concurrent writing
+        cannot garble the progress bar.
     progress_bar:
         If True, a progress bar will be displayed.
     return_exceptions:
@@ -502,13 +504,16 @@ def parallelize(
         sys.stdout = stdout.stream
         osw_logger.handlers = saved_handlers
         osw_logger.propagate = saved_propagate
-        if flush_at_end:
-            # in the finally block, so a failed batch still reports what its
-            # tasks had to say
-            for output, task_records in zip(outputs, records):
-                if output:
-                    print(output, end="")
-                for record in task_records:
+        # in the finally block, so a failed batch still reports what its
+        # tasks had to say
+        for output, task_records in zip(outputs, records):
+            if flush_at_end and output:
+                print(output, end="")
+            for record in task_records:
+                # A warning reports a problem, not progress, so a batch asked
+                # to stay quiet still passes it on. Discarding it would hide
+                # from the caller that something went wrong in a worker.
+                if flush_at_end or record.levelno >= logging.WARNING:
                     log_handler.replay(record)
 
     return results

--- a/src/osw/utils/wikitext.py
+++ b/src/osw/utils/wikitext.py
@@ -300,9 +300,7 @@ def find_dependencies(wikitext, debug=False):
         # see https://www.semantic-mediawiki.org/wiki/Help:Special_properties
         if "Property:" in dependency and (" " in dependency or "_" in dependency):
             if debug:
-                _logger.debug(
-                    f"Info: Remove presumptive built-in property {dependency}"
-                )
+                _logger.debug(f"Remove presumptive built-in property {dependency}")
         else:
             filtered_dependencies.append(dependency)
     return filtered_dependencies
@@ -404,7 +402,7 @@ def get_wikitext_from_flat_content_dict(d: dict) -> str:
                 else:
                     if string_index != index:
                         _logger.warning(
-                            f"Warning: template param '{key}' has mixed template/"
+                            f"template param '{key}' has mixed template/"
                             f"string values: {value}"
                         )
                     if string_index > 0 and element and not element.strip().isspace():
@@ -440,9 +438,7 @@ def get_wikitext_from_flat_content_structure(content):
         elif isinstance(content_element, str):
             wt += content_element  # "\n" + content_element
         else:
-            _logger.error(
-                f"Error: content element is not dict or string: {content_element}"
-            )
+            _logger.error(f"content element is not dict or string: {content_element}")
     return wt
 
 
@@ -473,7 +469,7 @@ def wikiJson2SchemaJson(schema, wikiJson):
         or not isinstance(wikiJson[1], str)
         or not isinstance(wikiJson[2], dict)
     ):
-        _logger.error(f"Error: Invalid wikiJson: {wikiJson}")
+        _logger.error(f"Invalid wikiJson: {wikiJson}")
         return schemaJson
 
     schemaJson = wikiJson2SchemaJsonRecursion(schema, wikiJson[0], wikiJson[2])
@@ -623,8 +619,7 @@ def schemaJson2WikiJson(schemaJson, isRoot=True):
         wikiJson[0][template] = {}
     else:
         _logger.error(
-            f"Error: Mandatory property 'osl_template' not found in schemaJson "
-            f"{schemaJson}"
+            f"Mandatory property 'osl_template' not found in schemaJson {schemaJson}"
         )
         return
 

--- a/src/osw/utils/wikitext.py
+++ b/src/osw/utils/wikitext.py
@@ -1,8 +1,11 @@
 import copy
+import logging
 
 import mwparserfromhell
 import numpy as np
 from jsonpath_ng.ext import parse
+
+_logger = logging.getLogger(__name__)
 
 """
 Module to transform wikitext / templates.
@@ -241,10 +244,10 @@ def find_dependencies(wikitext, debug=False):
     for template in code.filter_templates(recursive=True):
         if template.name.split(":")[0].isupper():
             if debug:
-                print(f"MagicWord: {template.name}")
+                _logger.debug(f"MagicWord: {template.name}")
         elif template.name[0] == "#":
             if debug:
-                print(f"ParserFunction: {template.name}")
+                _logger.debug(f"ParserFunction: {template.name}")
             if "#set:" in template.name or "#declare:" in template.name:
                 if (
                     "=" in template.name.split(":")[1]
@@ -252,41 +255,41 @@ def find_dependencies(wikitext, debug=False):
                     property_ = "Property:" + template.name.split(":")[1].split("=")[0]
                     dependencies.append(property_)
                     if debug:
-                        print(f"=> {property_}")
+                        _logger.debug(f"=> {property_}")
                 for param in template.params:
                     property_ = "Property:" + param.split("=")[0]
                     dependencies.append(property_)
                     if debug:
-                        print(f"=> {property_}")
+                        _logger.debug(f"=> {property_}")
         else:
             if debug:
-                print(f"Template: {template.name}")
+                _logger.debug(f"Template: {template.name}")
             template_name = str(template.name)
             if ":" not in template.name:
                 template_name = "Template:" + template_name
             dependencies.append(template_name)
             if debug:
-                print(f"=> {template_name}")
+                _logger.debug(f"=> {template_name}")
     # for tag in code.filter_tags(recursive=True):
     #    if (debug): print("Tag: {}".format(tag))
     for link in code.filter_wikilinks(recursive=True):
         if "::" in link:
             if debug:
-                print(f"Annotation: {link}")
+                _logger.debug(f"Annotation: {link}")
             property_ = "Property:" + link.split("::")[0].split("[[")[-1]
             dependencies.append(property_)
             if debug:
-                print(f"=> {property_}")
+                _logger.debug(f"=> {property_}")
         if "Category:" in link:
             if debug:
-                print(f"Category: {link}")
+                _logger.debug(f"Category: {link}")
             category = link.replace("[[", "").replace("]]", "")
             dependencies.append(str(category))
             if debug:
-                print(f"=> {category}")
+                _logger.debug(f"=> {category}")
         else:
             if debug:
-                print(f"Link: {link}")
+                _logger.debug(f"Link: {link}")
     dependencies = np.unique(dependencies).tolist()  # remove duplicates
     filtered_dependencies = []  # do not manipulate the iterated object
     for dependency in dependencies:
@@ -297,7 +300,9 @@ def find_dependencies(wikitext, debug=False):
         # see https://www.semantic-mediawiki.org/wiki/Help:Special_properties
         if "Property:" in dependency and (" " in dependency or "_" in dependency):
             if debug:
-                print(f"Info: Remove presumptive built-in property {dependency}")
+                _logger.debug(
+                    f"Info: Remove presumptive built-in property {dependency}"
+                )
         else:
             filtered_dependencies.append(dependency)
     return filtered_dependencies
@@ -331,7 +336,7 @@ def find_dependencies_recursively(title, site, dependencies=None, debug=False):
         if dependency not in dependencies:  # for circular dependencies
             dependencies.append(dependency)
             if debug:
-                print(f"Scan nested {dependency}")
+                _logger.debug(f"Scan nested {dependency}")
             find_dependencies_recursively(
                 dependency, site, dependencies=dependencies, debug=debug
             )
@@ -398,7 +403,7 @@ def get_wikitext_from_flat_content_dict(d: dict) -> str:
                     # wt += "\n}}"
                 else:
                     if string_index != index:
-                        print(
+                        _logger.warning(
                             f"Warning: template param '{key}' has mixed template/"
                             f"string values: {value}"
                         )
@@ -435,7 +440,9 @@ def get_wikitext_from_flat_content_structure(content):
         elif isinstance(content_element, str):
             wt += content_element  # "\n" + content_element
         else:
-            print(f"Error: content element is not dict or string: {content_element}")
+            _logger.error(
+                f"Error: content element is not dict or string: {content_element}"
+            )
     return wt
 
 
@@ -466,7 +473,7 @@ def wikiJson2SchemaJson(schema, wikiJson):
         or not isinstance(wikiJson[1], str)
         or not isinstance(wikiJson[2], dict)
     ):
-        print("Error: Invalid wikiJson:", wikiJson)
+        _logger.error(f"Error: Invalid wikiJson: {wikiJson}")
         return schemaJson
 
     schemaJson = wikiJson2SchemaJsonRecursion(schema, wikiJson[0], wikiJson[2])
@@ -615,9 +622,9 @@ def schemaJson2WikiJson(schemaJson, isRoot=True):
         template = schemaJson["osl_template"]
         wikiJson[0][template] = {}
     else:
-        print(
-            "Error: Mandatory property 'osl_template' not found in schemaJson",
-            schemaJson,
+        _logger.error(
+            f"Error: Mandatory property 'osl_template' not found in schemaJson "
+            f"{schemaJson}"
         )
         return
 

--- a/src/osw/utils/workflow.py
+++ b/src/osw/utils/workflow.py
@@ -1,6 +1,7 @@
 """Prefect utils as support for OpenSemanticWorld."""
 
 import asyncio
+import logging
 import os
 import re
 import sys
@@ -27,6 +28,8 @@ from osw.core import OSW
 from osw.utils._httpx_gateway import _install as _install_gateway_hook
 from osw.utils.wiki import get_full_title
 from osw.wtsite import WtSite
+
+_logger = logging.getLogger(__name__)
 
 # Auto-patch httpx at import time if PREFECT_API_URL is an ApiGateway URL.
 # This ensures the transport is active for ALL Prefect API calls, not just
@@ -192,16 +195,13 @@ class ApiGatewayTransport(httpx.AsyncBaseTransport):
         )
 
     async def handle_async_request(self, request: httpx.Request) -> httpx.Response:
-        import logging
-
-        log = logging.getLogger(__name__)
-        log.debug("ApiGateway: %s %s", request.method, request.url)
+        _logger.debug("ApiGateway: %s %s", request.method, request.url)
         rewritten = self._rewrite_request(request)
-        log.debug("ApiGateway rewritten: %s %s", rewritten.method, rewritten.url)
+        _logger.debug("ApiGateway rewritten: %s %s", rewritten.method, rewritten.url)
         # Create a fresh transport per request to avoid event-loop binding
         inner = httpx.AsyncHTTPTransport()
         response = await inner.handle_async_request(rewritten)
-        log.debug("ApiGateway response: %s", response.status_code)
+        _logger.debug("ApiGateway response: %s", response.status_code)
         # Follow redirects by rewriting internal Location URLs back
         # through the gateway (backend may return internal Docker URLs)
         if response.status_code in (301, 302, 307, 308):
@@ -221,7 +221,7 @@ class ApiGatewayTransport(httpx.AsyncBaseTransport):
                 if loc_parsed.query:
                     redirect_query.append(f"query={quote(loc_parsed.query, safe='')}")
                 redirect_url = f"{self._gateway_url}?{'&'.join(redirect_query)}"
-                log.debug("ApiGateway following redirect: %s", redirect_url)
+                _logger.debug("ApiGateway following redirect: %s", redirect_url)
                 redirect_req = httpx.Request(
                     method=(
                         rewritten.method
@@ -249,7 +249,7 @@ class ApiGatewayTransport(httpx.AsyncBaseTransport):
                     body = response.read().decode(errors="replace")
                 except Exception:
                     body = "<unreadable>"
-                log.warning(
+                _logger.warning(
                     "ApiGateway returned 403, re-authenticating. Response: %s",
                     body,
                 )
@@ -321,7 +321,7 @@ def install_gateway_hook():
     shutil.copy2(src, os.path.join(sp, _PTH_MODULE))
     with open(os.path.join(sp, _PTH_FILENAME), "w") as f:
         f.write(_PTH_CONTENT)
-    print(f"Installed gateway hook in {sp}")
+    _logger.info(f"Installed gateway hook in {sp}")
 
 
 def uninstall_gateway_hook():
@@ -331,7 +331,7 @@ def uninstall_gateway_hook():
         target = os.path.join(sp, name)
         if os.path.exists(target):
             os.remove(target)
-            print(f"Removed {target}")
+            _logger.info(f"Removed {target}")
 
 
 # ------------------------------ NOTIFICATIONS ---------------------
@@ -580,8 +580,8 @@ async def register_flow(
                 stale_entities.append(entity)
     if stale_entities:
         for e in stale_entities:
-            print(
-                f"WARNING: Deleting stale PrefectFlow entity "
+            _logger.warning(
+                f"Deleting stale PrefectFlow entity "
                 f"'{get_full_title(e)}' (superseded by '{new_flow_title}')"
             )
         osw_instance.delete_entity(
@@ -651,11 +651,7 @@ async def register_flow(
         f"{snippet}\n"
         "</pre>\n"
     )
-    import logging
-
-    logging.getLogger(__name__).debug(
-        "Writing usage template to '%s':\n%s", software_title, snippet
-    )
+    _logger.debug("Writing usage template to '%s':\n%s", software_title, snippet)
 
     page = osw_instance.site.get_page(
         WtSite.GetPageParam(titles=[software_title])

--- a/src/osw/wiki_tools.py
+++ b/src/osw/wiki_tools.py
@@ -1,4 +1,5 @@
 import getpass
+import logging
 from typing import Dict, List, Optional, Tuple, Union
 
 import mwclient
@@ -7,6 +8,8 @@ from opensemantic.v1 import OswBaseModel
 from pydantic.v1 import FilePath
 
 from osw.utils.util import parallelize
+
+_logger = logging.getLogger(__name__)
 
 # try import functions from wikitext.py (relies on the extra dependency osw[wikitext])
 try:
@@ -23,7 +26,7 @@ try:
     from osw.utils.wikitext import wikiJson2SchemaJsonRecursion  # noqa
 
 except ImportError:
-    print(
+    _logger.warning(
         "Hint: The extra dependency 'osw[wikitext]' "
         "is required for the full functionality of wiki_tools module."
     )
@@ -51,7 +54,7 @@ def read_domains_from_credentials_file(
                 raise ValueError("No domain found in accounts.pwd.yaml!")
             return domains_list, accounts_dict
         except yaml.YAMLError as exc_:
-            print(exc_)
+            _logger.error(exc_)
 
 
 def read_credentials_from_yaml(
@@ -85,7 +88,7 @@ def read_credentials_from_yaml(
                 user = accounts[domain]["username"]
                 password = accounts[domain]["password"]
             except yaml.YAMLError as exc:
-                print(exc)
+                _logger.error(exc)
     else:
         user = input("Enter bot username (username@botname)")
         password = getpass.getpass("Enter bot password")
@@ -185,14 +188,14 @@ def prefix_search(
             format="json",
         )
         if query.debug and len(result["query"]["prefixsearch"]) == 0:
-            print("No results")
+            _logger.debug("No results")
         if query.return_json:
             return result
 
         for page in result["query"]["prefixsearch"]:
             title = page["title"]
             if query.debug:
-                print(title)
+                _logger.debug(title)
             page_list.append(title)
         return page_list
 
@@ -244,9 +247,9 @@ def semantic_search(
         result = site.api("ask", query=single_query, format="json")
         if query.debug:
             if len(result["query"]["results"]) == 0:
-                print(f"Query '{single_query}' returned no results")
+                _logger.debug(f"Query '{single_query}' returned no results")
             else:
-                print(
+                _logger.debug(
                     "Query '{}' returned {} results".format(
                         single_query, len(result["query"]["results"])
                     )
@@ -258,7 +261,7 @@ def semantic_search(
             title = page["fulltext"]
             exists = page["exists"]
             if "#" not in title and query.debug:
-                print(title)
+                _logger.debug(title)
                 # original position of "page_list.append(title)" line
             if exists == "1":
                 page_list.append(title)
@@ -448,7 +451,7 @@ def get_file_info_and_usage(
 
         if len(api_request_result["query"]["pages"]) == 0:
             if query.debug:
-                print(f"Page not found: '{single_title}'!")
+                _logger.debug(f"Page not found: '{single_title}'!")
         else:
             image_info: List[Dict[str, str]] = []
             file_usage: List[Dict[str, Union[str, int]]] = []
@@ -469,7 +472,7 @@ def get_file_info_and_usage(
                 # todo: find out why this message is printed (sometimes) when using the
                 #  redirect,  which messes up the Progressbar
                 #  printed messages do not appear in the MessageBuffer
-                print(f"File info for '{single_title}' retrieved.")
+                _logger.debug(f"File info for '{single_title}' retrieved.")
         return {"info": file_info, "usage": using_pages}
 
     if query.parallel:
@@ -509,12 +512,12 @@ def search_redirection_sources(
     result = site.api("query", titles=target_title, prop="redirects", format="json")
     if len(result["query"]["pages"]) == 0:
         if debug:
-            print("No results")
+            _logger.debug("No results")
     else:
         for page in result["query"]["pages"]:
             if "redirects" not in result["query"]["pages"][page]:
                 if debug:
-                    print("No results")
+                    _logger.debug("No results")
             else:
                 for redirecting_source in result["query"]["pages"][page]["redirects"]:
                     title = redirecting_source["title"]

--- a/src/osw/wiki_tools.py
+++ b/src/osw/wiki_tools.py
@@ -1,7 +1,6 @@
 import getpass
 import logging
 import re
-import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
 import mwclient
@@ -327,7 +326,7 @@ def semantic_search(
         # count format does, means the result count says nothing about
         # truncation
         if limit and n >= limit:
-            warnings.warn(
+            _logger.warning(
                 f"Query '{single_query}' returned {n} results, which meets the "
                 f"requested limit of {limit}. Results are truncated - raise "
                 f"the limit or page through with '|offset=' to retrieve the "
@@ -348,7 +347,7 @@ def semantic_search(
             else:
                 dropped += 1
         if dropped > 0:
-            warnings.warn(
+            _logger.warning(
                 f"Query '{single_query}': {dropped} of {n} results were dropped "
                 f"because the wiki reported them as non-existing pages."
             )

--- a/src/osw/wiki_tools.py
+++ b/src/osw/wiki_tools.py
@@ -323,7 +323,10 @@ def semantic_search(
                 _logger.debug(f"Query '{single_query}' returned no results")
             else:
                 _logger.debug(f"Query '{single_query}' returned {n} results")
-        if n >= query.limit:
+        # No limit in force, or 'limit=0' asking for no results at all as a
+        # count format does, means the result count says nothing about
+        # truncation
+        if limit and n >= limit:
             warnings.warn(
                 f"Query '{single_query}' returned {n} results, which meets the "
                 f"requested limit of {limit}. Results are truncated - raise "

--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -3,6 +3,7 @@ caching OpenSemanticLab specific features are located in osw.core.OSW
 """
 
 import json
+import logging
 import os
 import shutil
 import threading
@@ -34,6 +35,8 @@ from osw.auth import CredentialManager
 from osw.utils.regex_pattern import REGEX_PATTERN_LIB
 from osw.utils.util import parallelize
 from osw.utils.wiki import get_osw_id
+
+_logger = logging.getLogger(__name__)
 
 # Constants
 SLOTS = {
@@ -438,7 +441,7 @@ class WtSite:
                         retry = param.retries
                         if param.raise_exception:
                             raise
-                print(msg)
+                _logger.info(msg)
             self._clear_cookies()
             return wtpage
 
@@ -625,18 +628,18 @@ class WtSite:
         if limit:
             titles = titles[0:limit]
         if log:
-            print(f"Found: {titles}")
+            _logger.debug(f"Found: {titles}")
         for title in titles:
             wtpage = self.get_page(WtSite.GetPageParam(titles=[title])).pages[0]
             modify_page(wtpage)
             if log:
-                print(f"\n======= {title} =======")
+                _logger.debug(f"\n======= {title} =======")
                 for slot in wtpage._slots:
                     content = wtpage.get_slot_content(slot)
                     # if isinstance(content, dict): content = json.dumps(content)
-                    print(f"   ==== {title}:{slot} ====   ")
+                    _logger.debug(f"   ==== {title}:{slot} ====   ")
                     pprint(content)
-                    print("\n")
+                    _logger.debug("\n")
             if not dryrun:
                 wtpage.edit(comment)
 
@@ -691,9 +694,11 @@ class WtSite:
             page.edit()
 
             if index is None:
-                print(f"Uploaded page to {page.get_url()}.")
+                _logger.info(f"Uploaded page to {page.get_url()}.")
             else:
-                print(f"({index + 1}/{max_index}): Uploaded page to {page.get_url()}.")
+                _logger.info(
+                    f"({index + 1}/{max_index}): Uploaded page to {page.get_url()}."
+                )
 
         if param.parallel:
             _ = parallelize(upload_page_, param.pages, flush_at_end=param.debug)
@@ -865,12 +870,12 @@ class WtSite:
         # Clear the content directory
         try:
             if debug:
-                print(f"Delete dir '{config.content_path}'")
+                _logger.debug(f"Delete dir '{config.content_path}'")
             if os.path.exists(config.content_path):
                 shutil.rmtree(config.content_path)
         except OSError as e:
             if debug:
-                print(f"Error: {e.filename} - {e.strerror}.")
+                _logger.error(f"Error: {e.filename} - {e.strerror}.")
         # Create a dump config
         if dump_config is None:
             dump_config = WtPage.PageDumpConfig(
@@ -885,7 +890,7 @@ class WtSite:
         added_titles = []  # keep track of added pages, prevent duplicates
 
         if config.name not in bundle.packages:
-            print(f"Error: package {config.name} does not exist in bundle")
+            _logger.error(f"Error: package {config.name} does not exist in bundle")
             return
         if not bundle.packages[config.name].pages:
             bundle.packages[config.name].pages = []
@@ -920,7 +925,7 @@ class WtSite:
             if config.include_files:
                 referenced_file_pages = page.find_file_page_refs_in_slots()
                 if debug and len(referenced_file_pages) > 0:
-                    print(
+                    _logger.debug(
                         f"File pages referenced in {page.title}: {referenced_file_pages}"
                     )
                 if param.config.ignore_titles is not None:
@@ -932,7 +937,7 @@ class WtSite:
                         set(referenced_file_pages) - set(included_file_pages)
                     )
                     if debug and len(ignored_files_pages) > 0:
-                        print(f"Ignored: {ignored_files_pages}")
+                        _logger.debug(f"Ignored: {ignored_files_pages}")
                     referenced_file_pages = included_file_pages
                 # find those files that are not already in the package
                 page_files[page.title] = list(
@@ -1047,10 +1052,10 @@ class WtSite:
         #  option or raise error
         if os.path.exists(pi_fp) and os.path.isfile(pi_fp):
             if debug:
-                print(f"Found packages info file at '{pi_fp}'.")
+                _logger.debug(f"Found packages info file at '{pi_fp}'.")
         else:
             if debug:
-                print(
+                _logger.debug(
                     f"Did not find packages info file at '{pi_fp}'. Trying default "
                     f"'packages.json'."
                 )
@@ -1066,7 +1071,9 @@ class WtSite:
                 pi_fp = json_in_top_level["file path"]
             elif len(top_level_json_files) > 0:
                 if debug:
-                    print(f"Found JSON files: {top_level_json_files}. Using first one.")
+                    _logger.debug(
+                        f"Found JSON files: {top_level_json_files}. Using first one."
+                    )
                 pi_fp = top_level_json_files[0]
             else:
                 raise FileNotFoundError(
@@ -1815,7 +1822,9 @@ class WtPage:
                 return self._edit(comment, mode, bot_edit)
             except Exception as e:
                 last_exc = e
-                print(f"Page edit failed: {e}. Retry ({attempt + 1}/{max_retry})")
+                _logger.warning(
+                    f"Page edit failed: {e}. Retry ({attempt + 1}/{max_retry})"
+                )
                 if attempt + 1 < max_retry:
                     # Attempt to recover the shared session before retrying.
                     # Guard the whole block: a recovery failure must never mask
@@ -1912,7 +1921,7 @@ class WtPage:
             whether to create a redirect from the old title to the new title
         """
         if new_title != self.title:
-            print(f"move '{self.title}' to '{new_title}'")
+            _logger.info(f"move '{self.title}' to '{new_title}'")
             self._page.move(
                 new_title=new_title, reason=comment, no_redirect=not redirect
             )
@@ -1973,13 +1982,13 @@ class WtPage:
                     if self.get_slot_content(slot) != slot_contents.get(slot, None):
                         changed_slots.append(slot)
                 if len(changed_slots) == 0:
-                    print(
+                    _logger.info(
                         f"Page '{self.title}' already has the same content. It will "
                         f"not be updated."
                     )
                     return WtPage.PageCopyResult(page=self, target_altered=False)
                 else:
-                    print(
+                    _logger.info(
                         f"Page '{self.title}' has different content in slots "
                         f"{changed_slots}."
                     )
@@ -1998,7 +2007,7 @@ class WtPage:
                     f"'https://{self.wtSite.mw_site.host}/w/index.php?title"
                     f"={self.title}&action=history'."
                 )
-            print(s2p)
+            _logger.info(s2p)
             return WtPage.PageCopyResult(page=self, target_altered=True)
 
     class PageDumpConfig(OswBaseModel):
@@ -2107,7 +2116,7 @@ class WtPage:
                 dump_slot_content(slot_key, content_type, content)
 
         if self.is_file_page():
-            print("download " + self.title)
+            _logger.info("download " + self.title)
             file = self.wtSite.mw_site.images[self.title.split(":")[-1]]
             file_name = f"{page_name}"
             file_path = os.path.join(tar_dir, *file_name.split("/"))  # handle subpages
@@ -2182,7 +2191,9 @@ class WtPage:
                     if ft is not None:
                         file_page_refs.append(ft)
                 except ValueError:
-                    print("Warning: Error while parsing uuid in editor template")
+                    _logger.warning(
+                        "Warning: Error while parsing uuid in editor template"
+                    )
         return list(set(file_page_refs))
 
     @try_and_renew_token
@@ -2302,7 +2313,7 @@ class WtPage:
         config.xml = config.xml.replace(
             'xmlns="http://www.mediawiki.org', '_xmlns="http://www.mediawiki.org'
         )
-        print(config.xml)
+        _logger.debug(config.xml)
         tree = et.fromstring(config.xml)  # noqa: S314 parses our own exported XML
 
         # Replace title and namespace with the requested ones

--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -875,7 +875,7 @@ class WtSite:
                 shutil.rmtree(config.content_path)
         except OSError as e:
             if debug:
-                _logger.error(f"Error: {e.filename} - {e.strerror}.")
+                _logger.error(f"{e.filename} - {e.strerror}.")
         # Create a dump config
         if dump_config is None:
             dump_config = WtPage.PageDumpConfig(
@@ -890,7 +890,7 @@ class WtSite:
         added_titles = []  # keep track of added pages, prevent duplicates
 
         if config.name not in bundle.packages:
-            _logger.error(f"Error: package {config.name} does not exist in bundle")
+            _logger.error(f"package {config.name} does not exist in bundle")
             return
         if not bundle.packages[config.name].pages:
             bundle.packages[config.name].pages = []
@@ -2191,9 +2191,7 @@ class WtPage:
                     if ft is not None:
                         file_page_refs.append(ft)
                 except ValueError:
-                    _logger.warning(
-                        "Warning: Error while parsing uuid in editor template"
-                    )
+                    _logger.warning("Error while parsing uuid in editor template")
         return list(set(file_page_refs))
 
     @try_and_renew_token

--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -14,7 +14,7 @@ from copy import deepcopy
 from datetime import datetime
 from io import StringIO
 from pathlib import Path
-from pprint import pprint
+from pprint import pformat
 from time import sleep
 from typing import Any, Dict, List, Optional, Union
 from warnings import warn
@@ -643,19 +643,21 @@ class WtSite:
             titles = titles[0:limit]
         if param.log:
             _logger.debug(f"Found: {titles}")
-        for title in titles:
+
+        def modify_single_result(title: str):
             wtpage = self.get_page(WtSite.GetPageParam(titles=[title])).pages[0]
             modify_page(wtpage)
-            if log:
+            if param.log:
                 _logger.debug(f"\n======= {title} =======")
                 for slot in wtpage._slots:
                     content = wtpage.get_slot_content(slot)
                     # if isinstance(content, dict): content = json.dumps(content)
                     _logger.debug(f"   ==== {title}:{slot} ====   ")
-                    pprint(content)
+                    _logger.debug(pformat(content))
                     _logger.debug("\n")
             if not param.dryrun:
-                wtpage.edit(comment)
+                wtpage.edit(param.comment)
+
         if param.parallel:
             _ = parallelize(modify_single_result, titles, flush_at_end=param.log)
         else:

--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -8,7 +8,6 @@ import os
 import shutil
 import threading
 import urllib
-import warnings
 import xml.etree.ElementTree as et
 from copy import deepcopy
 from datetime import datetime
@@ -17,7 +16,6 @@ from pathlib import Path
 from pprint import pformat
 from time import sleep
 from typing import Any, Dict, List, Optional, Union
-from warnings import warn
 
 import mwclient
 import pyld
@@ -420,10 +418,8 @@ class WtSite:
                     pages.append(wtpage)
                     if not wtpage.exists:
                         if param.raise_warning:
-                            warnings.warn(
-                                f"WARNING: Page with title '{title}' does not exist.",
-                                RuntimeWarning,
-                                3,
+                            _logger.warning(
+                                f"Page with title '{title}' does not exist."
                             )
                         # throw argument value exception if page does not exist
                         raise ValueError(f"Page with title '{title}' does not exist.")
@@ -833,7 +829,7 @@ class WtSite:
                 try:
                     page_ = self._site.pages[page_]
                 except Exception as e:
-                    warn(
+                    _logger.warning(
                         f"Page '{page_}' could not be added to the list of "
                         f"to-be-deleted pages. The following Exception occurred:\n{e}"
                     )
@@ -842,7 +838,7 @@ class WtSite:
                     return page_.delete(comment=comment)
                 return page_.delete(reason=comment)
             except Exception as e:
-                warn(
+                _logger.warning(
                     f"Page '{page_}' could not be deleted. "
                     f"The following Exception occurred:\n{e}"
                 )

--- a/tests/integration/performance_test.py
+++ b/tests/integration/performance_test.py
@@ -1,3 +1,4 @@
+import logging
 import time
 
 import pytest
@@ -8,7 +9,7 @@ from osw.utils.wiki import get_full_title
 from osw.wtsite import WtSite
 
 
-def test_fetch_and_load(wiki_domain, wiki_username, wiki_password, mocker):
+def test_fetch_and_load(wiki_domain, wiki_username, wiki_password, mocker, caplog):
     # create a credential file on the default path for osw express
     cm = CredentialManager()  # cred_filepath = Path.cwd() / "accounts.pwd.yaml")
     cm.add_credential(
@@ -74,17 +75,16 @@ def test_fetch_and_load(wiki_domain, wiki_username, wiki_password, mocker):
 
     assert len(result.pages) == 50
 
-    # we should get a warning for the non-existent page
-    # see https://docs.pytest.org/en/stable/how-to/capture-warnings.html
+    # we should get a log warning for the non-existent page
     pages[0] = "IDONOTEXIST"
-    with pytest.warns(RuntimeWarning) as record:
-        result = osw_express.site.get_page(
-            WtSite.GetPageParam(titles=pages[:50], raise_exception=False)
-        )
-        # assert that at least one warning message contains
-        # the missing page title to inform the user
-        assert any("IDONOTEXIST" in str(rec.message) for rec in record)
-        assert len(result.pages) == 50  # assert that the result is still returned
+    caplog.set_level(logging.WARNING, logger="osw")
+    result = osw_express.site.get_page(
+        WtSite.GetPageParam(titles=pages[:50], raise_exception=False)
+    )
+    # assert that at least one warning message contains
+    # the missing page title to inform the user
+    assert any("IDONOTEXIST" in record.message for record in caplog.records)
+    assert len(result.pages) == 50  # assert that the result is still returned
 
     # assert that ValueError is raised when the page does not exist
     pages[0] = "IDONOTEXIST"

--- a/tests/integration/test_express_init.py
+++ b/tests/integration/test_express_init.py
@@ -781,7 +781,6 @@ class TestImportWithFallback:
         with pytest.raises(ValueError, match="to_import"):
             import_with_fallback(None, {})
 
-    @pytest.mark.filterwarnings("ignore:No 'dependencies' were passed:UserWarning")
     def test_nonexistent_class_no_deps_raises(self):
         """When the class doesn't exist and no dependencies or osw_fpt
         are given, should raise AttributeError."""
@@ -1228,10 +1227,6 @@ class TestLiveUploadWithTargetFpt:
 class TestLiveImportWithFallback:
     """Test import_with_fallback fallback path with live wiki."""
 
-    @pytest.mark.filterwarnings("ignore:No 'dependencies' were passed:UserWarning")
-    @pytest.mark.filterwarnings(
-        "ignore:An exception occurred while loading the module dependencies:UserWarning"
-    )
     def test_live_fallback_fetches_from_wiki(
         self, wiki_domain, wiki_username, wiki_password
     ):

--- a/tests/test_download_filename_modes.py
+++ b/tests/test_download_filename_modes.py
@@ -4,6 +4,8 @@ Covers #94: a download can keep the OSW-ID it has on the wiki, use the original
 file name, or combine both.
 """
 
+import logging
+
 import pytest
 
 from osw.express import FilenameMode, build_target_fn
@@ -67,9 +69,11 @@ def test_a_directory_in_the_name_is_dropped():
 
 @pytest.mark.parametrize("name", [None, ""])
 @pytest.mark.parametrize("mode", [FilenameMode.name, FilenameMode.name_and_osw_id])
-def test_a_missing_name_falls_back_to_the_osw_id(mode, name):
-    with pytest.warns(UserWarning, match="No name is stored"):
-        assert build_target_fn(mode, OSW_ID_FN, name) == OSW_ID_FN
+def test_a_missing_name_falls_back_to_the_osw_id(mode, name, caplog):
+    caplog.set_level(logging.WARNING, logger="osw")
+    assert build_target_fn(mode, OSW_ID_FN, name) == OSW_ID_FN
+
+    assert any("No name is stored" in record.message for record in caplog.records)
 
 
 def test_an_unknown_mode_is_rejected():

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,10 +1,12 @@
 """Offline tests for the osw logging setup and its capture in parallelize.
 
-Covers #130: prints replaced by logging, on by default, and routed per worker
-thread so a parallel batch does not garble its own progress bar.
+Covers #130: prints replaced by logging, on by default, handed over to the
+calling application as soon as it configures logging of its own, and routed per
+worker thread so a parallel batch does not garble its own progress bar.
 """
 
 import logging
+from contextlib import contextmanager
 
 import pytest
 
@@ -30,9 +32,29 @@ class ListHandler(logging.Handler):
 def osw_logger():
     """Hands out the osw logger and puts its global state back afterwards"""
     logger = logging.getLogger("osw")
-    saved = (logger.handlers[:], logger.level, logger.propagate)
+    saved = (logger.handlers[:], logger.level, logger.propagate, osw._level_is_ours)
     yield logger
-    logger.handlers, logger.level, logger.propagate = saved
+    logger.handlers, logger.level, logger.propagate = saved[:3]
+    osw._level_is_ours = saved[3]
+
+
+@contextmanager
+def plain_logging():
+    """The root logger as a plain interpreter has it, for the block's duration
+
+    Lets a test exercise the branch where nothing has configured logging yet,
+    and then add a handler of its own to stand in for an application that
+    configures logging afterwards. A context manager rather than a fixture
+    because pytest attaches its capture handlers to the root logger around each
+    test phase, and the ones for the call phase go on after the fixtures ran.
+    """
+    root = logging.getLogger()
+    saved = root.handlers[:]
+    root.handlers = []
+    try:
+        yield root
+    finally:
+        root.handlers = saved
 
 
 @pytest.fixture
@@ -45,12 +67,37 @@ def collected(osw_logger):
     return handler
 
 
-def test_the_package_attaches_its_own_handler_on_import():
+def osw_default_handlers(logger):
+    """The handlers osw attached itself
+
+    Membership rather than list equality, because pytest's logging plugin
+    attaches capture handlers of its own to the loggers it collects from.
+    """
+    return [h for h in logger.handlers if h.get_name() == "osw-default"]
+
+
+def test_it_takes_the_output_when_nothing_else_has_it(osw_logger, monkeypatch):
     """Logging is on by default, so a caller who configures nothing still sees
     what osw is doing."""
-    names = [h.get_name() for h in logging.getLogger("osw").handlers]
+    monkeypatch.delenv(osw.LOG_LEVEL_ENV_VAR, raising=False)
 
-    assert "osw-default" in names
+    with plain_logging():
+        osw._configure_on_import()
+
+        assert osw_default_handlers(osw_logger)
+        assert osw_logger.level == osw.DEFAULT_LOG_LEVEL
+
+
+def test_it_stays_out_of_the_way_when_logging_is_already_configured(osw_logger):
+    """An application that configured logging before importing osw keeps sole
+    charge of the output."""
+    with plain_logging() as root:
+        root.addHandler(ListHandler())
+
+        osw._configure_on_import()
+
+        assert osw_default_handlers(osw_logger) == []
+        assert osw_logger.level == logging.NOTSET
 
 
 @pytest.mark.parametrize(
@@ -89,14 +136,56 @@ def test_enable_logging_does_not_stack_handlers(osw_logger):
     assert len(osw_default_handlers(osw_logger)) == 1
 
 
-def osw_default_handlers(logger):
-    """The handlers osw attached itself
+def test_the_osw_logger_always_propagates(osw_logger):
+    """Propagation is what carries the records to the application's handlers,
+    so osw never switches it off. Not writing twice is the handler's job."""
+    osw.enable_logging()
 
-    Membership rather than list equality, because pytest's logging plugin
-    attaches its own capture handlers to any logger that does not propagate,
-    which the osw logger does not while the default handler is on it.
-    """
-    return [h for h in logger.handlers if h.get_name() == "osw-default"]
+    assert osw_logger.propagate is True
+
+
+def test_the_handler_steps_aside_once_the_application_configures_logging(osw_logger):
+    """Configuring logging is the whole of what aggregating osw takes: the
+    records arrive at the application's handler, and osw stops writing its own
+    copy the next time it logs."""
+    with plain_logging() as root:
+        osw.enable_logging()
+        application = ListHandler()
+        root.addHandler(application)
+
+        logging.getLogger("osw.somewhere").warning("through the application")
+
+        assert osw_default_handlers(osw_logger) == []
+        assert application.messages() == ["through the application"]
+
+
+def test_the_default_level_goes_back_on_hand_over(osw_logger, monkeypatch):
+    """The level osw chose for itself would otherwise override the one the
+    application asked for."""
+    monkeypatch.delenv(osw.LOG_LEVEL_ENV_VAR, raising=False)
+
+    with plain_logging() as root:
+        osw.enable_logging()
+        root.addHandler(ListHandler())
+
+        logging.getLogger("osw.somewhere").warning("anything")
+
+        assert osw_logger.level == logging.NOTSET
+
+
+def test_a_level_the_caller_asked_for_survives_the_hand_over(osw_logger):
+    """set_log_level is how one asks for osw's debug records in an aggregated
+    setup, so the hand-over must not undo it."""
+    with plain_logging() as root:
+        osw.enable_logging()
+        osw.set_log_level(logging.DEBUG)
+        application = ListHandler()
+        root.addHandler(application)
+
+        logging.getLogger("osw.somewhere").debug("still wanted")
+
+        assert osw_logger.level == logging.DEBUG
+        assert application.messages() == ["still wanted"]
 
 
 def test_disable_logging_leaves_a_foreign_handler_alone(osw_logger):
@@ -112,15 +201,12 @@ def test_disable_logging_leaves_a_foreign_handler_alone(osw_logger):
     assert osw_default_handlers(osw_logger) == []
 
 
-def test_disable_logging_restores_propagation(osw_logger):
-    """Handing control back to the root logger is what lets an application take
-    over with basicConfig()."""
-    osw.enable_logging()
-    assert osw_logger.propagate is False
+def test_disable_logging_gives_the_level_back_too(osw_logger):
+    osw.enable_logging(level=logging.DEBUG)
 
     osw.disable_logging()
 
-    assert osw_logger.propagate is True
+    assert osw_logger.level == logging.NOTSET
 
 
 def test_set_log_level_filters_what_is_emitted(collected, osw_logger):
@@ -142,8 +228,8 @@ def test_handler_chain_stops_where_propagation_stops(osw_logger):
 
 
 def test_handler_chain_includes_ancestors_while_propagating(osw_logger):
-    """After disable_logging() the records land on the root logger, so the
-    chain has to keep walking to find where they actually go."""
+    """The osw logger propagates, so the chain has to keep walking to find
+    where the records actually go."""
     own = ListHandler()
     inherited = ListHandler()
     osw_logger.handlers = [own]
@@ -212,6 +298,20 @@ def test_worker_records_are_dropped_without_flush_at_end(collected):
     parallelize(_log_item, [1, 2, 3], flush_at_end=False, progress_bar=False)
 
     assert collected.messages(WORKER) == []
+
+
+def test_worker_records_reach_the_application_handler(osw_logger):
+    """The capture replays into whatever the handler chain holds, so a batch's
+    records land in the application's handlers like any other."""
+    with plain_logging() as root:
+        application = ListHandler()
+        root.addHandler(application)
+        osw_logger.handlers = []
+        osw_logger.setLevel(logging.DEBUG)
+
+        parallelize(_log_item, [1, 2], flush_at_end=True, progress_bar=False)
+
+        assert application.messages(WORKER) == ["handled 1", "handled 2"]
 
 
 def test_the_logger_is_restored_afterwards(collected, osw_logger):

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -1,0 +1,238 @@
+"""Offline tests for the osw logging setup and its capture in parallelize.
+
+Covers #130: prints replaced by logging, on by default, and routed per worker
+thread so a parallel batch does not garble its own progress bar.
+"""
+
+import logging
+
+import pytest
+
+import osw
+from osw.utils.util import ThreadRoutedLogHandler, handler_chain, parallelize
+
+
+class ListHandler(logging.Handler):
+    """Collects records so a test can assert on them"""
+
+    def __init__(self):
+        super().__init__()
+        self.records = []
+
+    def emit(self, record: logging.LogRecord):
+        self.records.append(record)
+
+    def messages(self, name: str = None):
+        return [r.getMessage() for r in self.records if name is None or r.name == name]
+
+
+@pytest.fixture
+def osw_logger():
+    """Hands out the osw logger and puts its global state back afterwards"""
+    logger = logging.getLogger("osw")
+    saved = (logger.handlers[:], logger.level, logger.propagate)
+    yield logger
+    logger.handlers, logger.level, logger.propagate = saved
+
+
+@pytest.fixture
+def collected(osw_logger):
+    """The osw logger with a single collecting handler on it"""
+    handler = ListHandler()
+    osw_logger.handlers = [handler]
+    osw_logger.propagate = False
+    osw_logger.setLevel(logging.DEBUG)
+    return handler
+
+
+def test_the_package_attaches_its_own_handler_on_import():
+    """Logging is on by default, so a caller who configures nothing still sees
+    what osw is doing."""
+    names = [h.get_name() for h in logging.getLogger("osw").handlers]
+
+    assert "osw-default" in names
+
+
+@pytest.mark.parametrize(
+    "value, expected",
+    [
+        ("DEBUG", logging.DEBUG),
+        ("debug", logging.DEBUG),
+        ("  warning  ", logging.WARNING),
+        ("10", 10),
+        ("OFF", osw.OFF),
+        ("NONE", osw.OFF),
+        ("SILENT", osw.OFF),
+        ("nonsense", osw.DEFAULT_LOG_LEVEL),
+        ("", osw.DEFAULT_LOG_LEVEL),
+    ],
+)
+def test_the_environment_variable_is_parsed_leniently(value, expected):
+    """An unusable value falls back rather than raising at import time."""
+    assert osw._parse_level(value) == expected
+
+
+def test_enable_logging_reads_the_environment_variable(osw_logger, monkeypatch):
+    monkeypatch.setenv(osw.LOG_LEVEL_ENV_VAR, "WARNING")
+
+    osw.enable_logging()
+
+    assert osw_logger.level == logging.WARNING
+
+
+def test_enable_logging_does_not_stack_handlers(osw_logger):
+    """Calling it again replaces the handler instead of adding a second one,
+    so messages are not emitted twice."""
+    osw.enable_logging()
+    osw.enable_logging()
+
+    assert len(osw_default_handlers(osw_logger)) == 1
+
+
+def osw_default_handlers(logger):
+    """The handlers osw attached itself
+
+    Membership rather than list equality, because pytest's logging plugin
+    attaches its own capture handlers to any logger that does not propagate,
+    which the osw logger does not while the default handler is on it.
+    """
+    return [h for h in logger.handlers if h.get_name() == "osw-default"]
+
+
+def test_disable_logging_leaves_a_foreign_handler_alone(osw_logger):
+    """Only the handler osw attached itself is removed. A handler the calling
+    application added keeps receiving records."""
+    foreign = ListHandler()
+    osw.enable_logging()
+    osw_logger.addHandler(foreign)
+
+    osw.disable_logging()
+
+    assert foreign in osw_logger.handlers
+    assert osw_default_handlers(osw_logger) == []
+
+
+def test_disable_logging_restores_propagation(osw_logger):
+    """Handing control back to the root logger is what lets an application take
+    over with basicConfig()."""
+    osw.enable_logging()
+    assert osw_logger.propagate is False
+
+    osw.disable_logging()
+
+    assert osw_logger.propagate is True
+
+
+def test_set_log_level_filters_what_is_emitted(collected, osw_logger):
+    osw.set_log_level(logging.WARNING)
+    log = logging.getLogger("osw.somewhere")
+
+    log.info("routine progress")
+    log.warning("something worth saying")
+
+    assert collected.messages() == ["something worth saying"]
+
+
+def test_handler_chain_stops_where_propagation_stops(osw_logger):
+    own = ListHandler()
+    osw_logger.handlers = [own]
+    osw_logger.propagate = False
+
+    assert handler_chain(osw_logger) == [own]
+
+
+def test_handler_chain_includes_ancestors_while_propagating(osw_logger):
+    """After disable_logging() the records land on the root logger, so the
+    chain has to keep walking to find where they actually go."""
+    own = ListHandler()
+    inherited = ListHandler()
+    osw_logger.handlers = [own]
+    osw_logger.propagate = True
+    root = logging.getLogger()
+    root.addHandler(inherited)
+    try:
+        chain = handler_chain(osw_logger)
+    finally:
+        root.removeHandler(inherited)
+
+    assert own in chain
+    assert inherited in chain
+
+
+def test_an_unregistered_thread_is_forwarded(osw_logger):
+    """The calling thread and tqdm keep writing straight through."""
+    wrapped = ListHandler()
+    handler = ThreadRoutedLogHandler([wrapped])
+    osw_logger.handlers = [handler]
+    osw_logger.setLevel(logging.DEBUG)
+
+    logging.getLogger("osw.caller").info("straight through")
+
+    assert wrapped.messages() == ["straight through"]
+
+
+def test_a_registered_thread_is_buffered(osw_logger):
+    wrapped = ListHandler()
+    handler = ThreadRoutedLogHandler([wrapped])
+    osw_logger.handlers = [handler]
+    osw_logger.setLevel(logging.DEBUG)
+    buffer = handler.register()
+    try:
+        logging.getLogger("osw.worker").info("held back")
+    finally:
+        handler.unregister()
+
+    assert wrapped.messages() == []
+    assert [r.getMessage() for r in buffer] == ["held back"]
+
+
+WORKER = "osw.worker"
+
+
+def _log_item(item):
+    logging.getLogger(WORKER).info(f"handled {item}")
+    return item
+
+
+def test_worker_records_are_replayed_in_input_order(collected):
+    """The tasks finish in whatever order they finish, so the replay is what
+    puts the messages back in the order of the iterable."""
+    parallelize(_log_item, [1, 2, 3, 4], flush_at_end=True, progress_bar=False)
+
+    assert collected.messages(WORKER) == [
+        "handled 1",
+        "handled 2",
+        "handled 3",
+        "handled 4",
+    ]
+
+
+def test_worker_records_are_dropped_without_flush_at_end(collected):
+    """flush_at_end=False means quiet, which is what debug=False asks for."""
+    parallelize(_log_item, [1, 2, 3], flush_at_end=False, progress_bar=False)
+
+    assert collected.messages(WORKER) == []
+
+
+def test_the_logger_is_restored_afterwards(collected, osw_logger):
+    parallelize(_log_item, [1], flush_at_end=True, progress_bar=False)
+
+    assert collected in osw_logger.handlers
+    assert not [h for h in osw_logger.handlers if isinstance(h, ThreadRoutedLogHandler)]
+    assert osw_logger.propagate is False
+
+
+def _fail_on_item(item):
+    logging.getLogger(WORKER).info(f"about to fail on {item}")
+    raise ValueError(item)
+
+
+def test_a_failed_batch_still_replays_and_restores(collected, osw_logger):
+    """The replay sits in a finally block, so a batch that raised still reports
+    what its tasks had to say."""
+    with pytest.raises(ValueError):
+        parallelize(_fail_on_item, [7], flush_at_end=True, progress_bar=False)
+
+    assert collected.messages(WORKER) == ["about to fail on 7"]
+    assert collected in osw_logger.handlers
+    assert not [h for h in osw_logger.handlers if isinstance(h, ThreadRoutedLogHandler)]

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -6,6 +6,7 @@ worker thread so a parallel batch does not garble its own progress bar.
 """
 
 import logging
+import sys
 from contextlib import contextmanager
 
 import pytest
@@ -134,6 +135,14 @@ def test_enable_logging_does_not_stack_handlers(osw_logger):
     osw.enable_logging()
 
     assert len(osw_default_handlers(osw_logger)) == 1
+
+
+def test_the_default_handler_writes_to_stderr(osw_logger):
+    """stdout carries a program's own output, and a protocol for anything that
+    speaks one over it, e.g. an MCP stdio server, so osw keeps off it."""
+    handler = osw.enable_logging()
+
+    assert handler.stream is sys.stderr
 
 
 def test_the_osw_logger_always_propagates(osw_logger):

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -289,6 +289,12 @@ def _log_item(item):
     return item
 
 
+def _warn_on_item(item):
+    logging.getLogger(WORKER).info(f"handled {item}")
+    logging.getLogger(WORKER).warning(f"trouble with {item}")
+    return item
+
+
 def test_worker_records_are_replayed_in_input_order(collected):
     """The tasks finish in whatever order they finish, so the replay is what
     puts the messages back in the order of the iterable."""
@@ -303,10 +309,62 @@ def test_worker_records_are_replayed_in_input_order(collected):
 
 
 def test_worker_records_are_dropped_without_flush_at_end(collected):
-    """flush_at_end=False means quiet, which is what debug=False asks for."""
+    """flush_at_end=False means quiet for progress, which is what debug=False
+    asks for."""
     parallelize(_log_item, [1, 2, 3], flush_at_end=False, progress_bar=False)
 
     assert collected.messages(WORKER) == []
+
+
+def test_worker_warnings_survive_a_quiet_batch(collected):
+    """A warning reports a problem rather than progress, so a batch asked to
+    stay quiet still passes it on. These call sites used warnings.warn before,
+    which parallelize never suppressed, so dropping them would lose output a
+    caller has today."""
+    parallelize(_warn_on_item, [1, 2], flush_at_end=False, progress_bar=False)
+
+    assert collected.messages(WORKER) == ["trouble with 1", "trouble with 2"]
+
+
+def test_worker_errors_survive_a_quiet_batch(collected):
+    """Errors are replayed on the same grounds as warnings. OSW.delete_entity
+    logs one from inside a worker it parallelizes, at src/osw/core.py."""
+
+    def _fail_quietly(item):
+        logging.getLogger(WORKER).error(f"could not handle {item}")
+
+    parallelize(_fail_quietly, [1], flush_at_end=False, progress_bar=False)
+
+    assert collected.messages(WORKER) == ["could not handle 1"]
+
+
+def test_worker_warnings_reach_pytests_caplog(caplog, osw_logger):
+    """caplog puts its handler on the root logger, so a replayed record has to
+    travel the same path as any other to be seen. The integration test
+    tests/integration/performance_test.py asserts on a warning from a parallel
+    get_page batch this way, and it needs wiki credentials to run."""
+    caplog.set_level(logging.WARNING, logger="osw")
+
+    parallelize(_warn_on_item, [1], flush_at_end=False, progress_bar=False)
+
+    assert any("trouble with 1" in record.message for record in caplog.records)
+
+
+def test_worker_warnings_are_replayed_in_input_order(collected):
+    """The tasks finish in whatever order they finish, so the warnings are put
+    back in the order of the iterable like everything else."""
+    parallelize(_warn_on_item, [1, 2, 3, 4], flush_at_end=True, progress_bar=False)
+
+    assert collected.messages(WORKER) == [
+        "handled 1",
+        "trouble with 1",
+        "handled 2",
+        "trouble with 2",
+        "handled 3",
+        "trouble with 3",
+        "handled 4",
+        "trouble with 4",
+    ]
 
 
 def test_worker_records_reach_the_application_handler(osw_logger):

--- a/tests/test_logging_setup.py
+++ b/tests/test_logging_setup.py
@@ -12,7 +12,12 @@ from contextlib import contextmanager
 import pytest
 
 import osw
-from osw.utils.util import ThreadRoutedLogHandler, handler_chain, parallelize
+from osw.utils.util import (
+    TASK_OUTPUT_LOGGER,
+    ThreadRoutedLogHandler,
+    handler_chain,
+    parallelize,
+)
 
 
 class ListHandler(logging.Handler):
@@ -403,3 +408,45 @@ def test_a_failed_batch_still_replays_and_restores(collected, osw_logger):
     assert collected.messages(WORKER) == ["about to fail on 7"]
     assert collected in osw_logger.handlers
     assert not [h for h in osw_logger.handlers if isinstance(h, ThreadRoutedLogHandler)]
+
+
+def _print_item(item):
+    print(f"printed {item}")
+    return item
+
+
+def _print_two_lines(item):
+    print("first line")
+    print("second line")
+    return item
+
+
+def test_task_output_is_logged_on_its_own_logger(collected):
+    """Captured print output carries its own logger name, distinct from
+    osw.utils.util where parallelize itself logs from, so a caller can filter
+    it apart from osw's own records."""
+    parallelize(_print_item, [1], flush_at_end=True, progress_bar=False)
+
+    record = next(r for r in collected.records if "printed 1" in r.getMessage())
+    assert record.name == TASK_OUTPUT_LOGGER
+    assert record.name != "osw.utils.util"
+
+
+def test_task_output_is_split_into_one_record_per_line(collected):
+    """A block of printed text arrives as a run of lines, each with its own
+    record, rather than one record holding the whole block."""
+    parallelize(_print_two_lines, [1], flush_at_end=True, progress_bar=False)
+
+    messages = [
+        r.getMessage() for r in collected.records if r.name == TASK_OUTPUT_LOGGER
+    ]
+    assert messages == ["first line", "second line"]
+
+
+def test_task_output_no_longer_reaches_real_stdout(capsys):
+    """Printed output is replayed through logging now, not written back to the
+    process's own stdout, which an MCP stdio server needs kept clear for the
+    JSON-RPC channel it carries."""
+    parallelize(_print_item, [1], flush_at_end=True, progress_bar=False)
+
+    assert "printed 1" not in capsys.readouterr().out

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -1,4 +1,4 @@
-import warnings
+import logging
 from unittest.mock import MagicMock
 
 import pytest
@@ -165,45 +165,46 @@ def test_semantic_search_parallel_batch_with_one_zero_result_query():
     ]
 
 
-def test_semantic_search_truncation_warning():
+def test_semantic_search_truncation_warning(caplog):
     titles = [f"Item:OSW{i}" for i in range(5)]
     result = _ask_result(*titles)
     site = MagicMock()
     site.api.return_value = result
 
-    with pytest.warns(UserWarning, match="truncated"):
-        out = wt.semantic_search(
-            site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=5)
-        )
+    caplog.set_level(logging.WARNING, logger="osw")
+    out = wt.semantic_search(
+        site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=5)
+    )
 
+    assert any("truncated" in record.message for record in caplog.records)
     assert sorted(out) == sorted(titles)
 
 
-def test_semantic_search_no_truncation_warning_below_limit():
+def test_semantic_search_no_truncation_warning_below_limit(caplog):
     titles = [f"Item:OSW{i}" for i in range(5)]
     result = _ask_result(*titles)
     site = MagicMock()
     site.api.return_value = result
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        out = wt.semantic_search(
-            site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=1000)
-        )
+    caplog.set_level(logging.WARNING, logger="osw")
+    out = wt.semantic_search(
+        site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=1000)
+    )
 
-    assert not any("truncated" in str(w.message) for w in caught)
+    assert not any("truncated" in record.message for record in caplog.records)
     assert sorted(out) == sorted(titles)
 
 
-def test_semantic_search_exists_drop_warning():
+def test_semantic_search_exists_drop_warning(caplog):
     result = _ask_result("Item:OSW1", "Item:OSW2")
     result["query"]["results"]["Item:OSW2"]["exists"] = ""
     site = MagicMock()
     site.api.return_value = result
 
-    with pytest.warns(UserWarning, match="non-existing"):
-        out = wt.semantic_search(site, "[[HasType::Category:Item]]")
+    caplog.set_level(logging.WARNING, logger="osw")
+    out = wt.semantic_search(site, "[[HasType::Category:Item]]")
 
+    assert any("non-existing" in record.message for record in caplog.records)
     assert out == ["Item:OSW1"]
 
 
@@ -264,15 +265,16 @@ def test_semantic_search_query_limit_beats_the_search_param_limit():
     assert site.api.call_args.kwargs["query"] == "[[HasType::Category:Item]]|limit=2"
 
 
-def test_semantic_search_truncation_warning_uses_the_query_limit():
+def test_semantic_search_truncation_warning_uses_the_query_limit(caplog):
     """The caller's limit is the one the results were truncated at."""
     titles = [f"Item:OSW{i}" for i in range(2)]
     site = MagicMock()
     site.api.return_value = _ask_result(*titles)
 
-    with pytest.warns(UserWarning, match="requested limit of 2"):
-        out = wt.semantic_search(site, "[[HasType::Category:Item]]|limit=2")
+    caplog.set_level(logging.WARNING, logger="osw")
+    out = wt.semantic_search(site, "[[HasType::Category:Item]]|limit=2")
 
+    assert any("requested limit of 2" in record.message for record in caplog.records)
     assert sorted(out) == sorted(titles)
 
 
@@ -299,44 +301,41 @@ def test_semantic_search_limit_none_keeps_a_limit_the_caller_wrote():
     assert site.api.call_args.kwargs["query"] == "[[HasType::Category:Item]]|limit=2"
 
 
-def test_semantic_search_limit_none_does_not_warn_about_truncation():
+def test_semantic_search_limit_none_does_not_warn_about_truncation(caplog):
     """With no limit in force the result count says nothing about truncation."""
     titles = [f"Item:OSW{i}" for i in range(5)]
     site = MagicMock()
     site.api.return_value = _ask_result(*titles)
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        out = wt.semantic_search(
-            site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=None)
-        )
+    caplog.set_level(logging.WARNING, logger="osw")
+    out = wt.semantic_search(
+        site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=None)
+    )
 
-    assert not any("truncated" in str(w.message) for w in caught)
+    assert not any("truncated" in record.message for record in caplog.records)
     assert sorted(out) == sorted(titles)
 
 
-def test_semantic_search_no_truncation_warning_for_a_zero_limit():
+def test_semantic_search_no_truncation_warning_for_a_zero_limit(caplog):
     """'limit=0' asks for no results, so meeting it is not truncation."""
     site = MagicMock()
     site.api.return_value = _ask_result_empty()
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        wt.semantic_search(site, "[[HasType::Category:Item]]|limit=0")
+    caplog.set_level(logging.WARNING, logger="osw")
+    wt.semantic_search(site, "[[HasType::Category:Item]]|limit=0")
 
-    assert not any("truncated" in str(w.message) for w in caught)
+    assert not any("truncated" in record.message for record in caplog.records)
 
 
-def test_semantic_search_no_truncation_warning_below_the_query_limit():
+def test_semantic_search_no_truncation_warning_below_the_query_limit(caplog):
     titles = [f"Item:OSW{i}" for i in range(2)]
     site = MagicMock()
     site.api.return_value = _ask_result(*titles)
 
-    with warnings.catch_warnings(record=True) as caught:
-        warnings.simplefilter("always")
-        wt.semantic_search(site, "[[HasType::Category:Item]]|limit=50")
+    caplog.set_level(logging.WARNING, logger="osw")
+    wt.semantic_search(site, "[[HasType::Category:Item]]|limit=50")
 
-    assert not any("truncated" in str(w.message) for w in caught)
+    assert not any("truncated" in record.message for record in caplog.records)
 
 
 def _prefixsearch_result(*titles):

--- a/tests/utils/parallelize_test.py
+++ b/tests/utils/parallelize_test.py
@@ -10,12 +10,13 @@ implementation moved from dask to asyncio, leaving both parameters inert.
 """
 
 import asyncio
+import logging
 import sys
 import threading
 
 import pytest
 
-from osw.utils.util import ThreadRoutedStdout, parallelize
+from osw.utils.util import TASK_OUTPUT_LOGGER, ThreadRoutedStdout, parallelize
 
 # Generous enough that a loaded CI machine still passes, short enough that a
 # serialized execution trips it instead of hanging the suite.
@@ -123,18 +124,22 @@ def _print_then_return(item):
     return item
 
 
-def test_flush_at_end_prints_what_the_tasks_printed(capsys):
+def test_flush_at_end_logs_what_the_tasks_printed(caplog):
+    caplog.set_level(logging.INFO, logger=TASK_OUTPUT_LOGGER)
+
     parallelize(_print_then_return, [1, 2, 3], flush_at_end=True)
 
-    out = capsys.readouterr().out
-    assert "handled 1" in out
-    assert "handled 2" in out
-    assert "handled 3" in out
+    messages = [r.message for r in caplog.records if r.name == TASK_OUTPUT_LOGGER]
+    assert "handled 1" in messages
+    assert "handled 2" in messages
+    assert "handled 3" in messages
 
 
-def test_flush_at_end_replays_in_input_order(capsys):
+def test_flush_at_end_replays_in_input_order(caplog):
     """Output follows the iterable, not the order the tasks happened to finish."""
     import time
+
+    caplog.set_level(logging.INFO, logger=TASK_OUTPUT_LOGGER)
 
     delays = {1: 0.05, 2: 0.0, 3: 0.03}
 
@@ -144,49 +149,47 @@ def test_flush_at_end_replays_in_input_order(capsys):
 
     parallelize(sleep_then_print, [1, 2, 3], flush_at_end=True)
 
-    out = capsys.readouterr().out
-    assert out.index("handled 1") < out.index("handled 2") < out.index("handled 3")
+    messages = [r.message for r in caplog.records if r.name == TASK_OUTPUT_LOGGER]
+    assert messages.index("handled 1") < messages.index("handled 2")
+    assert messages.index("handled 2") < messages.index("handled 3")
 
 
-def test_flush_at_end_defers_until_the_batch_is_done():
-    """Nothing reaches the real stdout while the tasks are still running."""
-    written = []
+def test_flush_at_end_defers_until_the_batch_is_done(caplog):
+    """Nothing reaches the osw.parallel.output logger while the tasks are still
+    running."""
     snapshots = []
     barrier = threading.Barrier(3, timeout=BARRIER_TIMEOUT)
 
-    class _Recorder:
-        def write(self, message):
-            written.append(message)
-            return len(message)
-
-        def flush(self):
-            pass
+    caplog.set_level(logging.INFO, logger=TASK_OUTPUT_LOGGER)
 
     def print_then_look(item):
         print(f"handled {item}")
         barrier.wait()  # every task has printed by the time this releases
-        snapshots.append("".join(written))
+        snapshots.append([
+            r.message for r in caplog.records if r.name == TASK_OUTPUT_LOGGER
+        ])
 
-    original = sys.stdout
-    sys.stdout = _Recorder()
-    try:
-        parallelize(print_then_look, [1, 2, 3], flush_at_end=True, progress_bar=False)
-    finally:
-        sys.stdout = original
+    parallelize(print_then_look, [1, 2, 3], flush_at_end=True, progress_bar=False)
 
-    # mid-flight the real stream had seen none of it, afterwards it has all of it
-    assert not any("handled" in snapshot for snapshot in snapshots)
-    assert "".join(written).count("handled") == 3
+    # mid-flight the logger had seen none of it, afterwards it has all of it
+    assert not any(
+        any("handled" in message for message in snapshot) for snapshot in snapshots
+    )
+    final = [r.message for r in caplog.records if r.name == TASK_OUTPUT_LOGGER]
+    assert sum("handled" in message for message in final) == 3
 
 
-def test_task_output_is_suppressed_without_flush_at_end(capsys):
+def test_task_output_is_suppressed_without_flush_at_end(caplog):
+    caplog.set_level(logging.INFO, logger=TASK_OUTPUT_LOGGER)
+
     parallelize(_print_then_return, [1, 2, 3])
 
-    assert "handled" not in capsys.readouterr().out
+    assert not any("handled" in record.message for record in caplog.records)
 
 
-def test_flush_at_end_reports_even_when_the_batch_fails(capsys):
+def test_flush_at_end_reports_even_when_the_batch_fails(caplog):
     """A failing item must not swallow the diagnostics of the others."""
+    caplog.set_level(logging.INFO, logger=TASK_OUTPUT_LOGGER)
 
     def print_then_fail(item):
         print(f"handled {item}")
@@ -197,7 +200,7 @@ def test_flush_at_end_reports_even_when_the_batch_fails(capsys):
     with pytest.raises(ValueError, match="boom"):
         parallelize(print_then_fail, [1, 2, 3], flush_at_end=True)
 
-    assert "handled 1" in capsys.readouterr().out
+    assert any("handled 1" in record.message for record in caplog.records)
 
 
 def test_stdout_is_restored_afterwards():


### PR DESCRIPTION
Closes https://github.com/OpenSemanticLab/osw-python/issues/130.

Scope and decisions were agreed in https://github.com/OpenSemanticLab/osw-python/issues/130#issuecomment-5512920892.

## Changes

- `src/osw/__init__.py`: the `osw` logger gets a `StreamHandler` at INFO on `sys.stdout`, plus `set_log_level()`, `disable_logging()`, `enable_logging()` and the `OSW_LOG_LEVEL` environment variable, which takes a level name, a level number, or `OFF`.
- That handler stands down as soon as the calling application configures logging of its own, so osw's records stay aggregatable. See "Handing over to the application" below.
- A one-time notice on import states the level and how to change it: `osw logs at INFO on the 'osw' logger. Use osw.set_log_level('WARNING') to see less, osw.disable_logging() to switch it off, or set OSW_LOG_LEVEL=OFF before import. Configuring logging yourself, e.g. with logging.basicConfig(), takes the output over automatically.`
- 113 of the 123 `print()` calls in `src/osw` become `_logger` calls on a per-module logger: 18 error, 12 warning, 23 info, 60 debug. Levels were chosen per call site from the message content.
- `src/osw/utils/util.py`: `ThreadRoutedLogHandler`, the log counterpart of the `ThreadRoutedStdout` added in https://github.com/OpenSemanticLab/osw-python/pull/154. `parallelize` buffers each worker thread's `LogRecord`s and replays them in the order of `iterable` when `flush_at_end` is set.
- 22 messages lose a leading `Error: `, `Warning: ` or `Info: ` label, which the formatter now emits as the level.
- `src/osw/utils/workflow.py` gets a module-level logger, replacing the `import logging` calls that sat inside function bodies at lines 195 and 654.
- `tests/test_logging_setup.py`: 29 offline tests.
- README documents the new controls and the hand-over.

## Rationale

Only two modules used `logging` before, and neither consistently: `core.py` had a proper `_logger` used for five error calls while the same file still had 29 prints.

Logging is on by default because a library that goes silent would break every existing notebook and script at once.

## Handing over to the application

The `osw` logger propagates at all times. osw never sets `propagate = False`, so its records always reach whatever handlers the calling application configured, on the `osw` logger or on the root logger above it. Aggregating osw into an application's logging therefore needs no osw-specific call, and works the same whether logging is configured before or after `import osw`.

Not writing the messages twice is the handler's job rather than propagation's:

- `_DefaultHandler.emit` first asks whether any handler exists above the `osw` logger. If one does, it detaches itself and writes nothing, so the application's handler is the only one reporting.
- The check runs at emit rather than at import, because a script normally imports osw before it calls `logging.basicConfig()`.
- The hand-over also resets the level osw picked back to `NOTSET`, so the application's level governs from then on. Without that, `basicConfig(level=WARNING)` would still see osw's INFO records, since ancestor logger levels are not consulted once a record exists.
- A level the caller asked for, through `set_log_level()`, `enable_logging(level=...)` or `OSW_LOG_LEVEL`, is kept across the hand-over. That is how one pulls osw's DEBUG records into an aggregated setup while the rest of the application stays quieter.
- When logging was already configured at import time, osw attaches nothing at all.

`disable_logging()` remains the explicit form of the same thing, and is needed for the one case osw cannot detect: a handler added to the `osw` logger itself, which is indistinguishable from one of osw's own.

## Interaction with #154

https://github.com/OpenSemanticLab/osw-python/pull/154 had just rebuilt output capture in `parallelize` around replacing `sys.stdout`, which works because `print()` resolves `sys.stdout` at call time. Converting the workers to logging would have bypassed it and silently undone that fix, since a `StreamHandler` writes to a stream captured at construction and defaults to stderr.

The routing is installed as a **handler** on the `osw` logger rather than a filter. A logger's filters run only for records logged on that logger itself, so a filter on `osw` would never see records from `osw.wtsite` and the other child loggers, which is exactly the traffic that needs capturing. `handler_chain()` walks to the root, so a batch's records are replayed into the application's handlers like any other.

`parallelize` does set `propagate = False` for the duration of a batch, which is what stops buffered records escaping to the root logger before the replay, and restores it in a `finally`.

The stdout router stays in place, so an external caller passing its own printing function to `parallelize` keeps working.

## Kept as prints

10 of the 123, deliberately:

- 8 in `src/osw/utils/util.py`: the replay machinery itself, in `MessageBuffer.flush`, `redirect_print`, `redirect_print_explicitly` and the `flush_at_end` replay. These write captured output to a caller-supplied file or buffer, they are not status messages.
- `src/osw/auth.py`: the "No credentials found, please use the prompt to login" message, which directly precedes the `input()` and `getpass()` calls it refers to.
- `src/osw/controller/entity.py`: `Entity.explain()`, a user-facing method whose whole purpose is to print.

The 22 prints in the `if __name__ == "__main__":` demo block of `util.py` and the 47 commented-out ones are untouched.

## Behaviour change

Output now carries a level and a module name, `[INFO] osw.wtsite: ...` instead of bare text, and goes through the `osw` logger, so it can be filtered, redirected or switched off. Anything previously printed at a debug-ish verbosity is now at DEBUG and therefore hidden at the default level. Callers that need the old volume can call `osw.set_log_level("DEBUG")`.

## Verification

Offline suite passes: 147 passed, 1 skipped, up from 118 passed, 1 skipped. `ruff check` and `ruff format --check` are clean over `src` and `tests`.

The hand-over was additionally checked in real interpreters rather than only under pytest, which holds handlers on the root logger throughout and so masks the default path. Seven cases, each producing exactly one copy of every message and losing none: plain import, `basicConfig()` after import, `basicConfig()` before import, an application asking for WARNING while osw defaults to INFO, `OSW_LOG_LEVEL=DEBUG` against an application at WARNING, `OSW_LOG_LEVEL=OFF`, and `set_log_level("DEBUG")` against an application at WARNING.

## Notes

- Two calls in `src/osw/ontology.py` passed a tuple as the message because of a stray pair of parentheses, so they logged `('remove value with unsupported language: ', 'de')`. Since stripping their redundant prefix touched those exact lines, the tuple was collapsed into a single string, matching the correct sibling call a few lines below.
- `src/osw/wtsite.py` `get_page_` has one call site whose message is either "Page loaded." or a retry failure. It is logged at INFO, since the level applies per call site and the failure is also recorded in `exceptions` and re-raised when appropriate.
- Unrelated, but it keeps tripping the large-file pre-commit hook: `graphify-out/` is not in `.gitignore`, so a 1.6 MB generated `graph.json` is offered on every `git add -A`.
- This touches 15 modules and will conflict with most of the open PR queue, so it is held until the rest has landed, then rebased onto `main`.
