### PR TITLE
fix(search): keep a limit the caller wrote into the ask query

### DIFF
--- a/src/osw/wiki_tools.py
+++ b/src/osw/wiki_tools.py
@@ -138,8 +138,9 @@ class SearchParam(OswBaseModel):
     parallel: Optional[bool] = None  # is set to true if query is a list longer than 5
     debug: Optional[bool] = False
     limit: Optional[int] = 1000
-    """the result limit to apply. Ignored by semantic_search for a query that
-    sets 'limit=' itself, since SMW honours the last limit in the query string"""
+    """the result limit to apply, None to apply none and leave it to the wiki.
+    Ignored by semantic_search for a query that sets 'limit=' itself, since SMW
+    honours the last limit in the query string"""
     return_json: Optional[bool] = False
 
     def __init__(self, **data):
@@ -289,7 +290,7 @@ def semantic_search(
     query :
         (List of) query text(s) or instance of SearchParam. A query that sets
         ``limit=`` itself keeps that limit; ``SearchParam.limit`` is only
-        appended to a query that does not.
+        appended to a query that does not, and only when it is not None.
 
     Returns
     -------
@@ -304,9 +305,11 @@ def semantic_search(
     def semantic_search_(single_query):
         page_list = list()
         # SMW honours the last limit in the query string, so appending the
-        # default would silently override a limit the caller wrote themselves
+        # default would silently override a limit the caller wrote themselves.
+        # A SearchParam limit of None asks for no limit at all, leaving the
+        # wiki to apply its own default
         limit = get_query_limit(single_query)
-        if limit is None:
+        if limit is None and query.limit is not None:
             limit = query.limit
             single_query += f"|limit={limit}"
         result = site.api("ask", query=single_query, format="json")
@@ -317,8 +320,9 @@ def semantic_search(
                 print(f"Query '{single_query}' returned no results")
             else:
                 print(f"Query '{single_query}' returned {n} results")
-        # 'limit=0' asks for no results at all, e.g. with a count format, so
-        # meeting it says nothing about truncation
+        # No limit in force, or 'limit=0' asking for no results at all as a
+        # count format does, means the result count says nothing about
+        # truncation
         if limit and n >= limit:
             warnings.warn(
                 f"Query '{single_query}' returned {n} results, which meets the "

--- a/src/osw/wiki_tools.py
+++ b/src/osw/wiki_tools.py
@@ -1,4 +1,5 @@
 import getpass
+import re
 import warnings
 from typing import Dict, List, Optional, Tuple, Union
 
@@ -137,6 +138,8 @@ class SearchParam(OswBaseModel):
     parallel: Optional[bool] = None  # is set to true if query is a list longer than 5
     debug: Optional[bool] = False
     limit: Optional[int] = 1000
+    """the result limit to apply. Ignored by semantic_search for a query that
+    sets 'limit=' itself, since SMW honours the last limit in the query string"""
     return_json: Optional[bool] = False
 
     def __init__(self, **data):
@@ -244,6 +247,36 @@ def _ask_results_as_dict(results: Union[dict, list]) -> dict:
     }
 
 
+CONDITION_PATTERN = re.compile(r"\[\[.*?\]\]", re.DOTALL)
+"""matches an SMW query condition, which may contain '|' as the disjunction
+operator and must therefore be removed before the parameters are split"""
+LIMIT_PARAM_PATTERN = re.compile(r"^limit\s*=\s*(\d+)$", re.IGNORECASE)
+"""matches a limit parameter of an SMW query, e.g. 'limit=100'"""
+
+
+def get_query_limit(query: str) -> Optional[int]:
+    """Returns the limit an SMW ask query sets itself, None if it sets none
+
+    Parameters
+    ----------
+    query :
+        an SMW ask query string, e.g. '[[Category:Item]]|?Name|limit=2'
+
+    Returns
+    -------
+    result:
+        the limit the query asks for, or None if the query does not set one or
+        sets one that is not a number
+    """
+    limit = None
+    for parameter in CONDITION_PATTERN.sub("", query).split("|"):
+        match = LIMIT_PARAM_PATTERN.match(parameter.strip())
+        if match:
+            # SMW honours the last limit in the query string
+            limit = int(match.group(1))
+    return limit
+
+
 def semantic_search(
     site: mwclient.client.Site, query: Union[str, List[str], SearchParam]
 ) -> Union[List[str], List[dict]]:
@@ -254,7 +287,9 @@ def semantic_search(
     site :
         Site object from mwclient lib
     query :
-        (List of) query text(s) or instance of SearchParam
+        (List of) query text(s) or instance of SearchParam. A query that sets
+        ``limit=`` itself keeps that limit; ``SearchParam.limit`` is only
+        appended to a query that does not.
 
     Returns
     -------
@@ -268,7 +303,12 @@ def semantic_search(
 
     def semantic_search_(single_query):
         page_list = list()
-        single_query += f"|limit={query.limit}"
+        # SMW honours the last limit in the query string, so appending the
+        # default would silently override a limit the caller wrote themselves
+        limit = get_query_limit(single_query)
+        if limit is None:
+            limit = query.limit
+            single_query += f"|limit={limit}"
         result = site.api("ask", query=single_query, format="json")
         results = _ask_results_as_dict(result["query"]["results"])
         n = len(results)
@@ -277,10 +317,12 @@ def semantic_search(
                 print(f"Query '{single_query}' returned no results")
             else:
                 print(f"Query '{single_query}' returned {n} results")
-        if n >= query.limit:
+        # 'limit=0' asks for no results at all, e.g. with a count format, so
+        # meeting it says nothing about truncation
+        if limit and n >= limit:
             warnings.warn(
                 f"Query '{single_query}' returned {n} results, which meets the "
-                f"requested limit of {query.limit}. Results are truncated - raise "
+                f"requested limit of {limit}. Results are truncated - raise "
                 f"the limit or page through with '|offset=' to retrieve the "
                 f"remainder."
             )

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -207,6 +207,99 @@ def test_semantic_search_exists_drop_warning():
     assert out == ["Item:OSW1"]
 
 
+@pytest.mark.parametrize(
+    "query, expected",
+    [
+        ("[[HasType::Category:Item]]", None),
+        ("[[HasType::Category:Item]]|limit=2", 2),
+        ("[[HasType::Category:Item]]|?Name|limit=2|offset=5", 2),
+        ("[[HasType::Category:Item]]| limit = 2 ", 2),
+        ("[[HasType::Category:Item]]|Limit=2", 2),
+        # SMW honours the last one, so that is the effective limit
+        ("[[HasType::Category:Item]]|limit=2|limit=7", 7),
+        # a limit inside a condition is a value, not a parameter
+        ("[[HasText::limit=2]]", None),
+        ("[[HasText::a||limit=2]]", None),
+        # a printout named 'limit', not the parameter
+        ("[[HasType::Category:Item]]|?limit", None),
+        # a printout parameter, which limits that printout and not the query
+        ("[[HasType::Category:Item]]|?Has subobject|+limit=3", None),
+        # not a number, so there is no limit to honour
+        ("[[HasType::Category:Item]]|limit=all", None),
+    ],
+)
+def test_get_query_limit(query, expected):
+    assert wt.get_query_limit(query) == expected
+
+
+def test_semantic_search_appends_the_default_limit():
+    site = MagicMock()
+    site.api.return_value = _ask_result("Item:OSW1")
+
+    wt.semantic_search(site, "[[HasType::Category:Item]]")
+
+    assert site.api.call_args.kwargs["query"] == (
+        "[[HasType::Category:Item]]|limit=1000"
+    )
+
+
+def test_semantic_search_keeps_a_limit_the_caller_wrote():
+    """Appending the default would override it, since SMW honours the last one."""
+    site = MagicMock()
+    site.api.return_value = _ask_result("Item:OSW1")
+
+    wt.semantic_search(site, "[[HasType::Category:Item]]|limit=2")
+
+    assert site.api.call_args.kwargs["query"] == "[[HasType::Category:Item]]|limit=2"
+
+
+def test_semantic_search_query_limit_beats_the_search_param_limit():
+    site = MagicMock()
+    site.api.return_value = _ask_result("Item:OSW1")
+
+    wt.semantic_search(
+        site, wt.SearchParam(query="[[HasType::Category:Item]]|limit=2", limit=500)
+    )
+
+    assert site.api.call_args.kwargs["query"] == "[[HasType::Category:Item]]|limit=2"
+
+
+def test_semantic_search_truncation_warning_uses_the_query_limit():
+    """The caller's limit is the one the results were truncated at."""
+    titles = [f"Item:OSW{i}" for i in range(2)]
+    site = MagicMock()
+    site.api.return_value = _ask_result(*titles)
+
+    with pytest.warns(UserWarning, match="requested limit of 2"):
+        out = wt.semantic_search(site, "[[HasType::Category:Item]]|limit=2")
+
+    assert sorted(out) == sorted(titles)
+
+
+def test_semantic_search_no_truncation_warning_for_a_zero_limit():
+    """'limit=0' asks for no results, so meeting it is not truncation."""
+    site = MagicMock()
+    site.api.return_value = _ask_result_empty()
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        wt.semantic_search(site, "[[HasType::Category:Item]]|limit=0")
+
+    assert not any("truncated" in str(w.message) for w in caught)
+
+
+def test_semantic_search_no_truncation_warning_below_the_query_limit():
+    titles = [f"Item:OSW{i}" for i in range(2)]
+    site = MagicMock()
+    site.api.return_value = _ask_result(*titles)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        wt.semantic_search(site, "[[HasType::Category:Item]]|limit=50")
+
+    assert not any("truncated" in str(w.message) for w in caught)
+
+
 def _prefixsearch_result(*titles):
     """Build a minimal MediaWiki ``prefixsearch`` API result dict."""
     return {

--- a/tests/test_wiki_tools.py
+++ b/tests/test_wiki_tools.py
@@ -276,6 +276,45 @@ def test_semantic_search_truncation_warning_uses_the_query_limit():
     assert sorted(out) == sorted(titles)
 
 
+def test_semantic_search_limit_none_sends_no_limit():
+    """None asks for no limit at all, leaving the wiki to apply its own."""
+    site = MagicMock()
+    site.api.return_value = _ask_result("Item:OSW1")
+
+    wt.semantic_search(
+        site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=None)
+    )
+
+    assert site.api.call_args.kwargs["query"] == "[[HasType::Category:Item]]"
+
+
+def test_semantic_search_limit_none_keeps_a_limit_the_caller_wrote():
+    site = MagicMock()
+    site.api.return_value = _ask_result("Item:OSW1")
+
+    wt.semantic_search(
+        site, wt.SearchParam(query="[[HasType::Category:Item]]|limit=2", limit=None)
+    )
+
+    assert site.api.call_args.kwargs["query"] == "[[HasType::Category:Item]]|limit=2"
+
+
+def test_semantic_search_limit_none_does_not_warn_about_truncation():
+    """With no limit in force the result count says nothing about truncation."""
+    titles = [f"Item:OSW{i}" for i in range(5)]
+    site = MagicMock()
+    site.api.return_value = _ask_result(*titles)
+
+    with warnings.catch_warnings(record=True) as caught:
+        warnings.simplefilter("always")
+        out = wt.semantic_search(
+            site, wt.SearchParam(query="[[HasType::Category:Item]]", limit=None)
+        )
+
+    assert not any("truncated" in str(w.message) for w in caught)
+    assert sorted(out) == sorted(titles)
+
+
 def test_semantic_search_no_truncation_warning_for_a_zero_limit():
     """'limit=0' asks for no results, so meeting it is not truncation."""
     site = MagicMock()


### PR DESCRIPTION
Noted as out of scope while probing https://github.com/OpenSemanticLab/osw-python/pull/150.

## The bug

`semantic_search` appended the default limit unconditionally:

```python
single_query += f"|limit={query.limit}"
```

SMW honours the last limit in the query string, so `[[Category:Item]]|limit=2` went out as `[[Category:Item]]|limit=2|limit=1000` and the caller's limit was silently ignored. Verified live against a wiki: it returned 1000 results, not 2.

## Changes

- `get_query_limit(query)`: returns the limit an SMW ask query sets itself, `None` if it sets none.
- `semantic_search`: append `SearchParam.limit` only to a query that does not set its own. A query that does is sent unchanged.
- The truncation warning from https://github.com/OpenSemanticLab/osw-python/pull/150 now compares against the limit in force rather than `SearchParam.limit`.
- `limit=0` no longer triggers that warning.
- `SearchParam.limit=None` now means "apply no limit and leave it to the wiki", instead of raising `TypeError`.
- Precedence and the `None` meaning documented on `SearchParam.limit` and in the `semantic_search` docstring.
- 11 parametrised cases for `get_query_limit`, 9 tests for `semantic_search`, all offline.

## Why the truncation warning had to change with it

`#150` warns when `n >= query.limit`. Once a caller's `|limit=2` is honoured, results are truncated at 2 while `query.limit` is still the default 1000, so `2 >= 1000` is false and the warning would never fire on exactly the queries most likely to hit their limit. The effective limit is now a local, used for both the append decision and the warning.

`limit=0` follows from the same local: `0 >= 0` would warn "returned 0 results, which meets the requested limit of 0. Results are truncated" on every count-style query. A zero limit asks for no results, so meeting it says nothing about truncation.

## SearchParam.limit = None

`limit` is typed `Optional[int]`, but `None` was never usable: it appended the literal `|limit=None` and then raised `TypeError` on `n >= None`. `src/osw/data/import_utility.py:809-823` works around it by building a `SearchParam` without the field at all when its own `limit` argument is `None`.

`None` now means what the type suggests: send no limit parameter and leave the wiki to apply its own default. No limit is then in force, so no truncation warning is emitted, since the result count says nothing about completeness.

Nothing can regress: every previous `limit=None` call raised.

The `import_utility` workaround is left in place. It is not equivalent to passing `None` through: omitting the field yields the `1000` default, while `None` would now yield SMW's own, much smaller default. Collapsing the branch would change how many results that caller gets.

## Parsing the limit out of a query

`|` is not a plain separator in SMW: `||` is the disjunction operator inside `[[...]]` conditions, so `[[Has p::a||limit=2]]` would split into a bogus `limit=2]]` segment. Conditions are removed before the parameters are split, and the parameter pattern is anchored:

```python
CONDITION_PATTERN = re.compile(r"\[\[.*?\]\]", re.DOTALL)
LIMIT_PARAM_PATTERN = re.compile(r"^limit\s*=\s*(\d+)$", re.IGNORECASE)
```

- Non-greedy `\[\[.*?\]\]` can only remove a prefix of a nested condition, never text past a `]]`, so it cannot swallow a following `|limit=`.
- Anchoring at `^limit` keeps the printout `|?limit` and the printout parameter `|?Has subobject|+limit=3` from being read as the query limit. Both limit something other than the query.
- Multiple limits: the last wins, matching SMW.
- `limit=` with a non-numeric value returns `None`, so the default is appended after it. `...|limit=all|limit=1000` is a well-formed parameter list and SMW takes the last, which is the behaviour before this change.

## Behaviour change

- A query string carrying `limit=` now wins over `SearchParam.limit`. Previously the `SearchParam` value always won, which is the bug.
- The truncation warning can now name a smaller limit than `SearchParam.limit`.
- `SearchParam.limit=None` sends no limit instead of raising. No caller could have relied on the old behaviour.

## Not covered

The truncation warning still only catches truncation at the *requested* limit. SMW additionally caps every request server-side at `$smwgQMaxLimit`, so a request above that cap is silently reduced and returns fewer results than asked for without any warning. Tracked in https://github.com/OpenSemanticLab/osw-python/issues/162, which also sketches reading SMW's own `query.meta.hasFurtherResults` flag instead of inferring truncation from the result count.

## Verification

Offline suite passes (156 passed, 1 skipped). No other call site in the repo builds an SMW ask string containing a limit, so nothing else changes behaviour.

