### PR TITLE
feat(wtsite): parametrize and parallelize modify_search_results

### DIFF
--- a/src/osw/wtsite.py
+++ b/src/osw/wtsite.py
@@ -573,11 +573,11 @@ class WtSite:
         return wt.semantic_search(self._site, query)
 
     class ModifySearchResultsParam(OswBaseModel):
-        """Todo: should become param of modify_search_results"""
+        """Parameter object for modify_search_results method."""
 
         mode: str
         """The search mode. Either 'prefix' or 'semantic'."""
-        query: wt.SearchParam
+        query: Union[str, wt.SearchParam]
         """The search query."""
         comment: str = None
         """The comment for the edit."""
@@ -585,13 +585,15 @@ class WtSite:
         """Whether to log changes."""
         dryrun: bool = False
         """if True, no actual changes are made"""
+        parallel: Optional[bool] = False
+        """If True, processes the search results in parallel."""
 
     @try_and_renew_token
     def modify_search_results(
         self,
-        mode: str,
-        query: str,
-        modify_page,
+        param: Union[str, ModifySearchResultsParam],
+        query: str = None,
+        modify_page=None,
         limit=None,
         comment=None,
         log=False,
@@ -602,34 +604,47 @@ class WtSite:
 
         Parameters
         ----------
-        mode
-            The search mode. Either 'prefix' or 'semantic'.
+        param
+            ModifySearchResultsParam object. For backwards compatibility, the
+            search mode ('prefix' or 'semantic') can be passed directly instead,
+            together with the deprecated keyword arguments below.
         query
-            The search query.
+            Deprecated, use param.query instead. The search query.
         modify_page
             The callback that modifies the pages.
         limit
             query limit, by default None
         comment
-            edit comment, by default None
+            Deprecated, use param.comment instead. edit comment, by default None
         log
-            log changes, by default False
+            Deprecated, use param.log instead. log changes, by default False
         dryrun
-            if True, no actual changes are made, by default False
+            Deprecated, use param.dryrun instead. if True, no actual changes are
+            made, by default False
         """
+        if not isinstance(param, WtSite.ModifySearchResultsParam):
+            param = WtSite.ModifySearchResultsParam(
+                mode=param,
+                query=query,
+                comment=comment,
+                log=log,
+                dryrun=dryrun,
+            )
+
         titles = []
-        if mode == "prefix":
-            titles = wt.prefix_search(self._site, query)
-        elif mode == "semantic":
-            titles = wt.semantic_search(self._site, query)
+        if param.mode == "prefix":
+            titles = wt.prefix_search(self._site, param.query)
+        elif param.mode == "semantic":
+            titles = wt.semantic_search(self._site, param.query)
         if limit:
             titles = titles[0:limit]
-        if log:
+        if param.log:
             print(f"Found: {titles}")
-        for title in titles:
+
+        def modify_single_result(title: str):
             wtpage = self.get_page(WtSite.GetPageParam(titles=[title])).pages[0]
             modify_page(wtpage)
-            if log:
+            if param.log:
                 print(f"\n======= {title} =======")
                 for slot in wtpage._slots:
                     content = wtpage.get_slot_content(slot)
@@ -637,8 +652,13 @@ class WtSite:
                     print(f"   ==== {title}:{slot} ====   ")
                     pprint(content)
                     print("\n")
-            if not dryrun:
-                wtpage.edit(comment)
+            if not param.dryrun:
+                wtpage.edit(param.comment)
+
+        if param.parallel:
+            _ = parallelize(modify_single_result, titles, flush_at_end=param.log)
+        else:
+            _ = [modify_single_result(title) for title in titles]
 
     class UploadPageParam(OswBaseModel):
         """Parameter object for upload_page method."""

--- a/tests/test_wtsite_modify_search_results.py
+++ b/tests/test_wtsite_modify_search_results.py
@@ -1,0 +1,146 @@
+"""Unit tests for WtSite.modify_search_results().
+
+Regression guard for #27: modify_search_results now accepts the previously
+unused ModifySearchResultsParam object, gains an optional parallel mode, and
+must keep the legacy keyword-argument call form working.
+"""
+
+import threading
+
+import osw.wtsite as wtsite_mod
+from osw.wtsite import WtPage, WtSite
+
+
+class _FakeSite:
+    """Stands in for mwclient.Site. No method on it should ever be touched."""
+
+    host = "example.org"
+
+
+def _make_fake_wtsite():
+    """A WtSite that performs no network calls."""
+    ws = WtSite.__new__(WtSite)
+    ws._session_lock = threading.RLock()
+    ws._site = _FakeSite()
+    return ws
+
+
+def _make_pages(wtsite, titles):
+    return {
+        title: WtPage(wtSite=wtsite, title=title, do_init=False) for title in titles
+    }
+
+
+def _stub_search(monkeypatch, titles):
+    """Both prefix_search and semantic_search return the same fixed titles."""
+    monkeypatch.setattr(wtsite_mod.wt, "prefix_search", lambda site, query: titles)
+    monkeypatch.setattr(wtsite_mod.wt, "semantic_search", lambda site, query: titles)
+
+
+def _stub_get_page(monkeypatch, ws, pages_by_title):
+    """WtSite.get_page returns the canned page instead of hitting the network."""
+
+    def fake_get_page(param):
+        title = param.titles[0]
+        return WtSite.GetPageResult(pages=[pages_by_title[title]], errors=[])
+
+    monkeypatch.setattr(ws, "get_page", fake_get_page)
+
+
+def _stub_edits(monkeypatch, pages_by_title, comments, lock=None):
+    """Records (title, comment) for every page.edit() call instead of editing."""
+
+    def make_recorder(page):
+        def _edit(comment=None):
+            if lock is not None:
+                with lock:
+                    comments.append((page.title, comment))
+            else:
+                comments.append((page.title, comment))
+
+        return _edit
+
+    for page in pages_by_title.values():
+        monkeypatch.setattr(page, "edit", make_recorder(page))
+
+
+def test_modify_search_results_with_param_object_sequential(monkeypatch):
+    """The new param-object call form produces the same result as the old loop."""
+    ws = _make_fake_wtsite()
+    titles = ["Item:OSW1", "Item:OSW2", "Item:OSW3"]
+    pages = _make_pages(ws, titles)
+    comments = []
+
+    _stub_search(monkeypatch, titles)
+    _stub_get_page(monkeypatch, ws, pages)
+    _stub_edits(monkeypatch, pages, comments)
+
+    handled = []
+
+    def modify_page(wtpage):
+        handled.append(wtpage.title)
+
+    param = WtSite.ModifySearchResultsParam(
+        mode="prefix", query="Item:", comment="[bot] test", dryrun=False
+    )
+    ws.modify_search_results(param, modify_page=modify_page)
+
+    assert handled == titles
+    assert comments == [(title, "[bot] test") for title in titles]
+
+
+def test_modify_search_results_parallel_processes_every_result(monkeypatch):
+    """Every search result is handled when parallel processing is enabled."""
+    ws = _make_fake_wtsite()
+    titles = [f"Item:OSW{i}" for i in range(8)]
+    pages = _make_pages(ws, titles)
+    comments = []
+    lock = threading.Lock()
+
+    _stub_search(monkeypatch, titles)
+    _stub_get_page(monkeypatch, ws, pages)
+    _stub_edits(monkeypatch, pages, comments, lock=lock)
+
+    handled = []
+
+    def modify_page(wtpage):
+        with lock:
+            handled.append(wtpage.title)
+
+    param = WtSite.ModifySearchResultsParam(
+        mode="prefix",
+        query="Item:",
+        comment="[bot] parallel",
+        parallel=True,
+    )
+    ws.modify_search_results(param, modify_page=modify_page)
+
+    assert sorted(handled) == sorted(titles)
+    assert sorted(comments) == sorted((title, "[bot] parallel") for title in titles)
+
+
+def test_modify_search_results_legacy_keyword_call_still_works(monkeypatch):
+    """The pre-existing positional/keyword call form is unchanged."""
+    ws = _make_fake_wtsite()
+    titles = ["Item:OSW1"]
+    pages = _make_pages(ws, titles)
+    comments = []
+
+    _stub_search(monkeypatch, titles)
+    _stub_get_page(monkeypatch, ws, pages)
+    _stub_edits(monkeypatch, pages, comments)
+
+    handled = []
+
+    ws.modify_search_results(
+        "prefix",
+        "Item:",
+        lambda wtpage: handled.append(wtpage.title),
+        limit=1,
+        comment="[bot] legacy",
+        log=False,
+        dryrun=False,
+    )
+
+    assert handled == titles
+    assert comments == [("Item:OSW1", "[bot] legacy")]


### PR DESCRIPTION
Closes https://github.com/OpenSemanticLab/osw-python/issues/27

## Changes

- `ModifySearchResultsParam` is now actually used as the parameter object of `WtSite.modify_search_results`; its stale "Todo: should become param of modify_search_results" docstring is gone.
- Added a `parallel` flag on that param class, dispatching through the existing `parallelize` helper with the same invocation style as `WtSite.upload_page`.
- Widened `ModifySearchResultsParam.query` from `wt.SearchParam` to `Union[str, wt.SearchParam]`. Without this, building the param from a legacy plain-string query raises a pydantic `ValidationError`, so the previously unused class could not be wired up as-is.
- The per-title work moved into a local `modify_single_result` closure, dispatched either sequentially or through `parallelize`.

## Backward compatibility

The first argument is renamed `mode` -> `param` and typed `Union[str, ModifySearchResultsParam]`, following the `if not isinstance(param, ...)` idiom already used by `upload_page` and `delete_page`. Passing the mode string plus the legacy `query`/`comment`/`log`/`dryrun` keywords still works and builds the param object internally.

All five call sites in `examples/page_manipulation.py` pass `mode`, `query` and `modify_page` positionally, so they are unaffected. Only a hypothetical `mode=` keyword call would break, the same trade-off already accepted for the renamed first argument of `delete_page` and `upload_page`.

`limit` and `modify_page` stay as separate arguments, since the pre-existing param class defines neither and adding them was out of scope here.

## Tests

`tests/test_wtsite_modify_search_results.py`, network calls stubbed the same way `tests/test_wtsite_upload_page.py` does, no credentials needed:
- param object, sequential: callback ran and the edit comment was applied to every title, in order
- `parallel=True` over 8 titles: every title handled and edited, asserted order-independently
- legacy keyword/positional call form still works

Full unit suite: 171 passed, 1 skipped.

## Note for the merge order

This touches the same `print` calls inside `modify_search_results` that https://github.com/OpenSemanticLab/osw-python/pull/160 converts to `_logger.debug`. Whichever lands second will need to reconcile them; the prints here were moved into the new closure, not changed.