### PR TITLE
fix(core): address follow-up issues in the overwrite policy

### DIFF
--- a/src/osw/controller/file/local.py
+++ b/src/osw/controller/file/local.py
@@ -11,6 +11,9 @@ from osw.core import model
 class LocalFileController(FileController, model.LocalFile):
     """File controller for local files"""
 
+    type: Optional[List[str]] = model.LocalFile.__fields__["type"].get_default()
+    """LocalFile's category. FileController precedes model.LocalFile in the MRO, so
+    without this the field would resolve to model.File's category instead."""
     label: Optional[List[model.Label]] = [model.Label(text="Unnamed file")]
     """The label of the file, defaults to 'Unnamed file'"""
     path: Path

--- a/src/osw/controller/file/memory.py
+++ b/src/osw/controller/file/memory.py
@@ -11,6 +11,9 @@ from osw.core import model
 class InMemoryController(FileController, model.LocalFile):
     """File controller for in-memory streams"""
 
+    type: Optional[List[str]] = model.LocalFile.__fields__["type"].get_default()
+    """LocalFile's category. FileController precedes model.LocalFile in the MRO, so
+    without this the field would resolve to model.File's category instead."""
     label: Optional[List[model.Label]] = [model.Label(text="Unnamed stream")]
     """the label of the stream, e.g., the name of the file the stream
     originates from. Defaults to 'Unnamed stream'."""

--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -1782,7 +1782,7 @@ class OSW(BaseModel):
         skipped: Dict[str, WtPage] = {}
         """Existing pages that were not written because the applicable overwrite
         setting was 'keep existing', keyed by full page title. These also appear in
-        'pages', where they are indistinguishable from pages that were written."""
+        'pages'; subtract them to get the pages that were actually written."""
         failed: Dict[str, Exception] = {}
         """Entities that could not be stored, keyed by full page title and mapped to
         the exception that caused the failure. Empty on full success."""
@@ -1794,13 +1794,20 @@ class OSW(BaseModel):
         """Raised by store_entity() when one or more entities could not be stored.
 
         Carries the partial ``StoreEntityResult`` so callers can learn exactly which
-        entities were written (``stored`` / ``result.pages``) and which failed
-        (``failed`` / ``result.failed``) without a separate existence query.
+        entities were written (``stored``), which existed already and were left
+        untouched by 'keep existing' (``skipped``), and which failed (``failed`` /
+        ``result.failed``) without a separate existence query.
         """
 
         def __init__(self, result: OSW.StoreEntityResult):
             self.result = result
-            self.stored = list(result.pages.keys())
+            # a page kept by 'keep existing' was not written, so it does not
+            # belong in 'stored'. 'result.pages' still lists it, for callers
+            # that only care about which entities are on the wiki afterwards.
+            self.skipped = list(result.skipped.keys())
+            self.stored = [
+                title for title in result.pages if title not in result.skipped
+            ]
             self.failed = result.failed
             total = len(result.pages) + len(result.failed)
             failed_titles = ", ".join(result.failed.keys())

--- a/src/osw/core.py
+++ b/src/osw/core.py
@@ -145,6 +145,46 @@ class AddOverwriteClassOptions(Enum):
 OVERWRITE_CLASS_OPTIONS = Union[OverwriteOptions, AddOverwriteClassOptions]
 
 
+def _explicitly_set_empty(entity: OswBaseModel, jsondata: dict) -> dict:
+    """Returns the top-level jsondata entries the caller set to an empty value.
+
+    remove_empty() cannot tell an empty value that was assigned on purpose from
+    one that is merely a default, so it strips both. Assigning an empty value is
+    how a property gets cleared, though: the merge in _apply_overwrite_policy()
+    starts from the remote content, so a local key that was stripped leaves the
+    remote value in place and the property can never be emptied. pydantic records
+    the fields that were explicitly supplied in __fields_set__, which is enough to
+    keep those and drop the rest.
+
+    Parameters
+    ----------
+    entity:
+        The entity the jsondata was serialized from
+    jsondata:
+        The serialized entity, before remove_empty() has been applied
+
+    Returns
+    -------
+    result:
+        The subset of jsondata that is empty but was explicitly set
+    """
+    fields_set = getattr(entity, "__fields_set__", None)
+    if not fields_set:
+        return {}
+    fields = getattr(entity, "__fields__", {})
+    keys = set()
+    for name in fields_set:
+        # json() is called without by_alias, so the key is the field name. Accept
+        # the alias too, so that a field declared with one (model.PrefectFlow
+        # names 'schema_' after 'schema') is matched either way.
+        keys.add(name)
+        if name in fields:
+            keys.add(fields[name].alias)
+    return {
+        key: value for key, value in jsondata.items() if key in keys and is_empty(value)
+    }
+
+
 class OSW(BaseModel):
     """Bundles core functionalities of OpenSemanticWorld (OSW)"""
 
@@ -1411,6 +1451,19 @@ class OSW(BaseModel):
                     f"'{self.overwrite.value}', which acts on the entity as a "
                     f"whole. Use an OverwriteOptions value for 'overwrite'."
                 )
+            if self.per_property:
+                unknown = [
+                    key for key in self.per_property if key not in self.model.__fields__
+                ]
+                if unknown:
+                    # validate_per_property() only runs at construction and when
+                    # 'per_property' itself is assigned. Reassigning 'model' would
+                    # otherwise just drop the now-unknown keys from the rebuilt
+                    # mapping, leaving a setting that silently never applies.
+                    raise ValueError(
+                        f"Property not found in model '{self.model.__name__}': "
+                        f"{', '.join(unknown)}"
+                    )
             per_property_ = self.per_property or {}
             self._per_property = {
                 field_name: per_property_.get(field_name, self.overwrite)
@@ -1553,7 +1606,14 @@ class OSW(BaseModel):
         # We want those not to be listed as keys
         local_content["jsondata"] = json.loads(param.entity.json(exclude_none=True))
         if param.remove_empty:
+            # an empty value the caller assigned on purpose is how a property gets
+            # cleared, so it has to survive remove_empty() and reach the merge
+            # below, where step c) can let it win over the remote value
+            explicitly_set_empty = _explicitly_set_empty(
+                param.entity, local_content["jsondata"]
+            )
             remove_empty(local_content["jsondata"])
+            local_content["jsondata"].update(explicitly_set_empty)
         if param.debug:
             print(f"'local_content': {local_content!s}")
         # Apply the overwrite logic
@@ -1622,9 +1682,28 @@ class OSW(BaseModel):
         overwrite_per_class: Optional[List[OSW.OverwriteClassParam]] = None
         """A list of OverwriteClassParam objects. If a class specific overwrite setting
         is set, this setting is used.
+
+        Each object is copied when it is validated into this parameter, so it is a
+        snapshot taken here: configure a policy fully before passing it, since
+        mutating it afterwards no longer affects this StoreEntityParam.
+
+        A class is identified by its OSW type. A subclass that does not redefine
+        'type' therefore shares its parent's policy and cannot be given one of its
+        own. Generated model classes always redefine it; hand-written subclasses
+        such as the file controllers do not.
         """
         remove_empty: Optional[bool] = True
-        """If true, remove key with an empty string value from the jsondata."""
+        """If true, remove key with an empty string value from the jsondata.
+
+        A top-level property that was explicitly assigned an empty value is kept
+        rather than stripped, so that '', [] or {} reaches the merge. Whether it
+        then clears the stored value still depends on the overwrite setting for
+        that property: 'true' clears it, 'only empty' clears it only if the stored
+        value is empty too, and 'false' (or 'keep existing', the default) leaves
+        the stored value in place.
+
+        Assign None instead of an empty value for 'not known', otherwise the
+        property is cleared on the wiki."""
         change_id: Optional[str] = None
         """ID to document the change. Entities within the same store_entity() call will
         share the same change_id. This parameter can also be used to link multiple
@@ -1639,11 +1718,9 @@ class OSW(BaseModel):
         offline: Optional[bool] = False
         """If set to True, the processed entities are not upload but only returned as WtPages.
         Can be used to create WtPage objects from entities without uploading them."""
-        _overwrite_per_class: Dict[str, Dict[str, OSW.OverwriteClassParam]] = (
-            PrivateAttr()
-        )
-        """Private attribute, for internal use only. Use 'overwrite_per_class'
-        instead."""
+        _overwrite_per_class: Dict[str, OSW.OverwriteClassParam] = PrivateAttr()
+        """Private attribute, for internal use only. Maps the OSW type of a model
+        class to its policy. Use 'overwrite_per_class' instead."""
 
         def __init__(self, **data):
             super().__init__(**data)
@@ -1666,22 +1743,32 @@ class OSW(BaseModel):
                 )
             if self.overwrite is None:
                 self.overwrite = self.__fields__["overwrite"].get_default()
-            self._overwrite_per_class = {"by name": {}, "by type": {}}
+            self._overwrite_per_class = {}
             if self.overwrite_per_class is not None:
                 for param in self.overwrite_per_class:
-                    model_name = param.model.__name__
                     model_type = param.model.__fields__["type"].get_default()[0]
-                    if (
-                        model_name in self._overwrite_per_class["by name"].keys()
-                        or model_type in self._overwrite_per_class["by type"].keys()
-                    ):
+                    declared = self._overwrite_per_class.get(model_type)
+                    if declared is not None:
+                        other = declared.model
+                        detail = ""
+                        # issubclass(X, X) is True, so the same class declared
+                        # twice would otherwise be blamed on inheritance
+                        if param.model is not other and (
+                            issubclass(param.model, other)
+                            or issubclass(other, param.model)
+                        ):
+                            detail = (
+                                " A subclass that does not redefine 'type' inherits "
+                                "it, so store_entity() cannot tell the two apart. "
+                                "Declare a single OverwriteClassParam for both."
+                            )
                         raise ValueError(
-                            f"More than one OverwriteClassParam for the class "
-                            f"'{model_type}' ({model_name}) has been passed in the "
-                            f"list to 'overwrite_per_class'!"
+                            f"More than one OverwriteClassParam for the type "
+                            f"'{model_type}' has been passed in the list to "
+                            f"'overwrite_per_class': '{other.__name__}' and "
+                            f"'{param.model.__name__}'.{detail}"
                         )
-                    self._overwrite_per_class["by name"][model_name] = param
-                    self._overwrite_per_class["by type"][model_type] = param
+                    self._overwrite_per_class[model_type] = param
 
     class StoreEntityResult(OswBaseModel):
         """Result of store_entity()"""
@@ -1689,8 +1776,13 @@ class OSW(BaseModel):
         change_id: str
         """The ID of the change"""
         pages: Dict[str, WtPage]
-        """The pages that have been successfully stored, keyed by full page title.
-        On partial failure this contains only the successfully-stored pages."""
+        """The pages that have been successfully processed, keyed by full page title.
+        On partial failure this contains only the successfully-processed pages.
+        Includes the pages listed in 'skipped', which were left untouched."""
+        skipped: Dict[str, WtPage] = {}
+        """Existing pages that were not written because the applicable overwrite
+        setting was 'keep existing', keyed by full page title. These also appear in
+        'pages', where they are indistinguishable from pages that were written."""
         failed: Dict[str, Exception] = {}
         """Entities that could not be stored, keyed by full page title and mapped to
         the exception that caused the failure. Empty on full success."""
@@ -1739,6 +1831,7 @@ class OSW(BaseModel):
 
         max_index = len(param.entities)
         created_pages = {}
+        skipped_pages = {}
 
         meta_category_templates = {}
         if param.namespace == "Category":
@@ -1872,6 +1965,8 @@ class OSW(BaseModel):
                         f"'{page.get_url()}'."
                     )
             created_pages[page.title] = page
+            if kept_existing:
+                skipped_pages[page.title] = page
 
         sorted_entities = OSW.sort_list_of_entities_by_class(param.entities)
         print(
@@ -1894,7 +1989,7 @@ class OSW(BaseModel):
         upload_index = 0
         for class_type, entities in sorted_entities.by_type.items():
             # Try to get a class specific overwrite setting
-            class_param = param._overwrite_per_class["by type"].get(class_type, None)
+            class_param = param._overwrite_per_class.get(class_type, None)
             if class_param is None:
                 entity_model = entities[0].__class__
                 class_param = OSW.OverwriteClassParam(
@@ -1970,7 +2065,10 @@ class OSW(BaseModel):
                 failed[title] = result
 
         store_result = OSW.StoreEntityResult(
-            change_id=param.change_id, pages=created_pages, failed=failed
+            change_id=param.change_id,
+            pages=created_pages,
+            skipped=skipped_pages,
+            failed=failed,
         )
         if failed:
             # Surface partial/total failure so callers cannot mistake a dropped

--- a/src/osw/utils/workflow.py
+++ b/src/osw/utils/workflow.py
@@ -560,7 +560,10 @@ async def register_flow(
         description=[model.Description(text=flow.description or "")],
         flow_id=str(flow_uuid),
         hosted_software=[get_full_title(this_tool)],
-        domain=prefect_domain,
+        # None rather than "" when the hostname is unknown, like url_path above:
+        # an explicitly assigned empty value is written and would clear a domain
+        # already stored on the wiki
+        domain=prefect_domain or None,
         schema_=prefect_schema,
         network_port=prefect_port,
         url_path=prefect_path,

--- a/tests/test_controller_type_defaults.py
+++ b/tests/test_controller_type_defaults.py
@@ -1,0 +1,42 @@
+"""Pins that every file controller keeps the OSW category of its wrapped model.
+
+A controller's 'type' field decides which wiki category an entity is stored
+under. If a controller does not redefine 'type', it can silently inherit a
+different category from earlier in its MRO, filing pages under the wrong
+class.
+"""
+
+import osw.model.entity as model
+from osw.controller.file.base import FileController
+from osw.controller.file.local import LocalFileController
+from osw.controller.file.memory import InMemoryController
+from osw.controller.file.wiki import WikiFileController
+
+
+def test_file_controller_keeps_files_category():
+    assert (
+        FileController.__fields__["type"].get_default()
+        == model.File.__fields__["type"].get_default()
+    )
+
+
+def test_local_file_controller_keeps_local_files_category():
+    assert (
+        LocalFileController.__fields__["type"].get_default()
+        == model.LocalFile.__fields__["type"].get_default()
+    )
+
+
+def test_in_memory_controller_keeps_local_files_category():
+    """Same base order as LocalFileController, so the same category applies."""
+    assert (
+        InMemoryController.__fields__["type"].get_default()
+        == model.LocalFile.__fields__["type"].get_default()
+    )
+
+
+def test_wiki_file_controller_keeps_wiki_files_category():
+    assert (
+        WikiFileController.__fields__["type"].get_default()
+        == model.WikiFile.__fields__["type"].get_default()
+    )

--- a/tests/test_overwrite_policy.py
+++ b/tests/test_overwrite_policy.py
@@ -19,7 +19,12 @@ from typing import Any, Dict, Union
 import pytest
 
 import osw.model.entity as model
-from osw.core import OSW, AddOverwriteClassOptions, OverwriteOptions
+from osw.core import (
+    OSW,
+    AddOverwriteClassOptions,
+    OverwriteOptions,
+    _explicitly_set_empty,
+)
 from osw.utils.wiki import remove_empty
 from osw.wtsite import WtPage, WtSite
 
@@ -156,6 +161,111 @@ def test_remote_property_unknown_to_the_model_is_preserved(remote_and_local):
 
 
 # --------------------------------------------------------------------------
+# clearing a property
+# --------------------------------------------------------------------------
+
+
+@pytest.fixture
+def remote_item_with_description():
+    return model.Item(
+        label=[model.Label(text="Remote label")],
+        name="RemoteName",
+        description=[model.Label(text="Remote description")],
+    )
+
+
+def test_an_explicitly_emptied_property_clears_the_remote_value(
+    remote_item_with_description,
+):
+    remote = remote_item_with_description
+    local = model.Item(
+        uuid=remote.uuid,
+        type=remote.type,
+        label=[model.Label(text="Local label")],
+        description=[],
+    )
+    policy = OSW.OverwriteClassParam(model=model.Item, overwrite=OverwriteOptions.true)
+    result = apply_policy(make_remote_page(remote), local, policy)
+
+    assert result["description"] == []
+
+
+def test_a_property_that_was_never_set_does_not_clear_the_remote_value(
+    remote_item_with_description,
+):
+    """A field left at its None default never reaches the merge at all."""
+    remote = remote_item_with_description
+    local = model.Item(
+        uuid=remote.uuid, type=remote.type, label=[model.Label(text="Local label")]
+    )
+    policy = OSW.OverwriteClassParam(model=model.Item, overwrite=OverwriteOptions.true)
+    result = apply_policy(make_remote_page(remote), local, policy)
+
+    assert result["description"][0]["text"] == "Remote description"
+
+
+def test_an_empty_value_that_was_not_explicitly_set_is_still_stripped(
+    remote_item_with_description,
+):
+    """remove_empty() still runs: only __fields_set__ decides what survives it.
+
+    The generated models default every field to None, and None is dropped before
+    remove_empty() is reached, so __fields_set__ has to be edited directly to
+    produce the one case that tells the two apart: a value that is empty in the
+    serialized output but was not assigned by the caller.
+    """
+    remote = remote_item_with_description
+    local = model.Item(
+        uuid=remote.uuid,
+        type=remote.type,
+        label=[model.Label(text="Local label")],
+        description=[],
+    )
+    local.__fields_set__.discard("description")  # as if it had never been assigned
+    assert json.loads(local.json(exclude_none=True))["description"] == []
+
+    policy = OSW.OverwriteClassParam(model=model.Item, overwrite=OverwriteOptions.true)
+    result = apply_policy(make_remote_page(remote), local, policy)
+
+    assert result["description"][0]["text"] == "Remote description"
+
+
+def test_an_explicitly_emptied_property_is_still_protected_by_overwrite_false(
+    remote_item_with_description,
+):
+    remote = remote_item_with_description
+    local = model.Item(
+        uuid=remote.uuid,
+        type=remote.type,
+        label=[model.Label(text="Local label")],
+        description=[],
+    )
+    policy = OSW.OverwriteClassParam(model=model.Item, overwrite=OverwriteOptions.false)
+    result = apply_policy(make_remote_page(remote), local, policy)
+
+    assert result["description"][0]["text"] == "Remote description"
+
+
+def test_explicitly_set_empty_returns_only_the_fields_set_to_empty():
+    entity_with_empty_description = model.Item(
+        label=[model.Label(text="Local label")], description=[]
+    )
+    jsondata = json.loads(entity_with_empty_description.json(exclude_none=True))
+    assert _explicitly_set_empty(entity_with_empty_description, jsondata) == {
+        "description": []
+    }
+
+    entity_without_description = model.Item(label=[model.Label(text="Local label")])
+    jsondata_without_description = json.loads(
+        entity_without_description.json(exclude_none=True)
+    )
+    assert (
+        _explicitly_set_empty(entity_without_description, jsondata_without_description)
+        == {}
+    )
+
+
+# --------------------------------------------------------------------------
 # mutating a policy object after construction
 # --------------------------------------------------------------------------
 
@@ -209,6 +319,28 @@ def test_a_reassigned_policy_is_honoured_by_the_merge(remote_and_local):
 
     assert result["name"] == "LocalName"
     assert result["label"][0]["text"] == "Remote label"
+
+
+def test_reassigning_model_to_one_missing_a_per_property_key_is_rejected():
+    policy = OSW.OverwriteClassParam(
+        model=model.Item,
+        overwrite=False,
+        per_property={"description": OverwriteOptions.true},
+    )
+    with pytest.raises(ValueError, match="Property not found in model"):
+        policy.model = model.Label
+
+    assert policy.model is model.Item
+    assert policy.per_property == {"description": OverwriteOptions.true}
+
+
+def test_reassigning_model_to_one_that_has_the_key_still_applies_the_setting():
+    policy = OSW.OverwriteClassParam(
+        model=model.Item, per_property={"label": OverwriteOptions.true}
+    )
+    policy.model = model.Entity
+
+    assert policy.get_overwrite_setting("label") == OverwriteOptions.true
 
 
 # --------------------------------------------------------------------------
@@ -422,6 +554,46 @@ def test_two_policies_for_the_same_class_are_rejected():
         )
 
 
+class _SubItem(model.Item):
+    """A subclass that does not redefine 'type' and so shares model.Item's."""
+
+
+def test_a_subclass_sharing_the_parents_type_is_rejected_with_an_explanation():
+    with pytest.raises(ValueError, match="subclass that does not redefine"):
+        OSW.StoreEntityParam(
+            entities=[model.Item(label=[model.Label(text="x")])],
+            overwrite_per_class=[
+                OSW.OverwriteClassParam(model=model.Item, overwrite=True),
+                OSW.OverwriteClassParam(model=_SubItem, overwrite=False),
+            ],
+        )
+
+
+def test_the_same_class_declared_twice_is_not_blamed_on_inheritance():
+    """issubclass(X, X) is True, so the common typo must not cite a subclass."""
+    with pytest.raises(ValueError) as exc_info:
+        OSW.StoreEntityParam(
+            entities=[model.Item(label=[model.Label(text="x")])],
+            overwrite_per_class=[
+                OSW.OverwriteClassParam(model=model.Item, overwrite=True),
+                OSW.OverwriteClassParam(model=model.Item, overwrite=False),
+            ],
+        )
+
+    assert "subclass that does not redefine" not in str(exc_info.value)
+
+
+def test_overwrite_per_class_dispatch_map_is_flat_and_keyed_by_osw_type():
+    policy = OSW.OverwriteClassParam(model=model.Item, overwrite=OverwriteOptions.true)
+    param = OSW.StoreEntityParam(
+        entities=[model.Item(label=[model.Label(text="x")])],
+        overwrite_per_class=[policy],
+    )
+
+    assert set(param._overwrite_per_class.keys()) == {"Category:Item"}
+    assert param._overwrite_per_class["Category:Item"].model is model.Item
+
+
 # --------------------------------------------------------------------------
 # keep existing
 # --------------------------------------------------------------------------
@@ -515,3 +687,75 @@ def test_keep_existing_does_not_regenerate_the_schema_of_a_category(monkeypatch)
     page = _store_category(monkeypatch, AddOverwriteClassOptions.keep_existing)
 
     assert page.get_slot_content("jsonschema") is None
+
+
+# --------------------------------------------------------------------------
+# skipped pages
+# --------------------------------------------------------------------------
+
+
+def test_keep_existing_reports_a_skipped_page_that_already_existed(monkeypatch):
+    _stub_page_io(monkeypatch, exists=True)
+    osw_obj = OSW.construct(site=object())
+
+    item = model.Item(label=[model.Label(text="Keep me")])
+    result = osw_obj.store_entity(
+        OSW.StoreEntityParam(
+            entities=[item],
+            overwrite=AddOverwriteClassOptions.keep_existing,
+            parallel=False,
+        )
+    )
+
+    title = f"Item:{OSW.get_osw_id(item.uuid)}"
+    assert title in result.skipped
+    assert title in result.pages
+
+
+def test_skipped_pages_are_reported_from_the_parallel_path(monkeypatch):
+    """store_entity_() fills the dict from worker threads when parallel is set."""
+    _stub_page_io(monkeypatch, exists=True)
+    osw_obj = OSW.construct(site=object())
+
+    items = [model.Item(label=[model.Label(text=f"Keep {i}")]) for i in range(3)]
+    result = osw_obj.store_entity(
+        OSW.StoreEntityParam(
+            entities=items,
+            overwrite=AddOverwriteClassOptions.keep_existing,
+            parallel=True,
+        )
+    )
+
+    titles = {f"Item:{OSW.get_osw_id(item.uuid)}" for item in items}
+    assert set(result.skipped) == titles
+
+
+def test_a_newly_created_page_is_not_reported_as_skipped(monkeypatch):
+    _stub_page_io(monkeypatch, exists=False)
+    osw_obj = OSW.construct(site=object())
+
+    item = model.Item(label=[model.Label(text="Create me")])
+    result = osw_obj.store_entity(
+        OSW.StoreEntityParam(
+            entities=[item],
+            overwrite=AddOverwriteClassOptions.keep_existing,
+            parallel=False,
+        )
+    )
+
+    assert result.skipped == {}
+    assert f"Item:{OSW.get_osw_id(item.uuid)}" in result.pages
+
+
+def test_an_overwritten_existing_page_is_not_reported_as_skipped(monkeypatch):
+    _stub_page_io(monkeypatch, exists=True)
+    osw_obj = OSW.construct(site=object())
+
+    item = model.Item(label=[model.Label(text="Overwrite me")])
+    result = osw_obj.store_entity(
+        OSW.StoreEntityParam(
+            entities=[item], overwrite=OverwriteOptions.true, parallel=False
+        )
+    )
+
+    assert result.skipped == {}

--- a/tests/test_store_entity_failure.py
+++ b/tests/test_store_entity_failure.py
@@ -8,7 +8,7 @@ fails for selected page titles.
 import pytest
 
 import osw.model.entity as model
-from osw.core import OSW
+from osw.core import OSW, AddOverwriteClassOptions
 from osw.utils.wiki import get_namespace, get_title
 from osw.wtsite import WtPage
 
@@ -84,6 +84,37 @@ def test_store_entity_all_success_returns_result(offline_osw, monkeypatch):
 
     assert set(result.pages.keys()) == set(titles)
     assert result.failed == {}
+
+
+def test_partial_error_does_not_count_a_skipped_page_as_stored(
+    offline_osw, monkeypatch
+):
+    """'keep existing' leaves a page untouched, so it was not stored."""
+    keep, ok, boom = (
+        model.Item(label=[model.Label(text=text)]) for text in ("Keep", "Ok", "Boom")
+    )
+    keep_title, ok_title, boom_title = (_title(it) for it in (keep, ok, boom))
+    # only the kept entity is already on the wiki; the other two are created
+    monkeypatch.setattr(
+        WtPage, "init", lambda self: setattr(self, "exists", self.title == keep_title)
+    )
+    _install_edit(monkeypatch, {boom_title})
+
+    with pytest.raises(OSW.StoreEntityPartialError) as exc_info:
+        offline_osw.store_entity(
+            OSW.StoreEntityParam(
+                entities=[keep, ok, boom],
+                overwrite=AddOverwriteClassOptions.keep_existing,
+                parallel=False,
+            )
+        )
+
+    err = exc_info.value
+    assert err.stored == [ok_title]
+    assert err.skipped == [keep_title]
+    assert set(err.failed) == {boom_title}
+    # the kept page is still on the wiki, so it stays in 'pages'
+    assert keep_title in err.result.pages
 
 
 def test_store_entity_serial_all_success_returns_result(offline_osw, monkeypatch):


### PR DESCRIPTION
Follow-up to #163, which is now merged. Addresses the six issues listed there under "Found but not fixed", after a design pass with the maintainer, plus two defects found on the way.

## Behaviour changes

**A property can now be cleared by assigning an empty value.**
`remove_empty=True` (the default) stripped `''`/`[]`/`{}` from the local content before the merge, and since the merge starts from the remote content, the stored value always survived. Clearing was only possible by turning `remove_empty` off for the whole call.
`_explicitly_set_empty()` uses pydantic's `__fields_set__` to keep an empty value the caller assigned on purpose, and still strips one that is merely a default. Whether it then clears depends on the overwrite setting as usual: `true` clears, `only empty` clears only an empty remote, `false` and `keep existing` do not.

Assign `None`, not `''`, for "not known" - an explicitly empty value is now written.

**`StoreEntityResult.skipped`.** Pages that existed and were left untouched by `keep existing` were indistinguishable from pages that were written. They are now also listed in `skipped`. Additive: they remain in `pages`, so no existing caller breaks.

**`StoreEntityPartialError.stored` no longer counts skipped pages.** It derived from `result.pages`, which lists kept pages too, so a page that was deliberately left untouched was reported as stored. `stored` now excludes them and the error carries its own `skipped` list. `result.pages` is unchanged, for callers that only care about which entities are on the wiki afterwards.

**`OverwriteClassParam.model` reassignment re-validates `per_property`.** Assigning a `model` that lacks a declared property silently dropped the setting. It now raises, and `__setattr__` rolls the field back.

## Non-behaviour changes

**Subclass dispatch: kept, error message improved.** Dispatch stays keyed on the OSW `type` default. Declaring policies for a class and a subclass that inherits `type` still raises, but the message now names both classes and explains the cause. Generated model classes always redefine `type` (verified: 11 of 11 subclass pairs), so this only reaches hand-written subclasses such as the file controllers. `WikiFileController.put` casts to `model.WikiFile` before storing, so the collision is not reachable through the library itself.

**Dead code removed.** `StoreEntityParam._overwrite_per_class` was `{"by name": {...}, "by type": {...}}`; the `by name` half was built and duplicate-checked but never read. It is now a flat dict keyed by OSW type.

**Snapshot semantics documented.** pydantic v1 shallow-copies each policy into `overwrite_per_class`, so mutating one afterwards does not affect the param. Confirmed as intended: the snapshot is the wanted behaviour, so this is a docstring, not a code change.

## Defects found while doing the above

**`LocalFileController` and `InMemoryController` were filed under the wrong category.** Both declare `(FileController, model.LocalFile)`, and `FileController` extends `model.File`, so pydantic resolved `type` to `File`'s category instead of `LocalFile`'s. Both now declare `type` explicitly, read from `model.LocalFile` rather than hardcoded. `RemoteFileController`, `S3FileController` and `WikiFileController` put the model class first and were already correct.

**`register_workflow` would have cleared `PrefectFlow.domain`.** `utils/workflow.py` set `domain=parsed.hostname or ""` and stored with `overwrite=True`. Harmless before, destructive under the clearing change: with `PREFECT_API_URL` unset it would have written `""` over a stored domain. Now `or None`, matching the neighbouring `url_path`.

## Tests

19 added: 14 in `tests/test_overwrite_policy.py`, 4 in the new `tests/test_controller_type_defaults.py`, 1 in `tests/test_store_entity_failure.py`.

Reverting the source changes fails 11 of them, one per behaviour change; the rest are characterisation coverage. `test_an_empty_value_that_was_not_explicitly_set_is_still_stripped` edits `__fields_set__` directly, because the generated models default every field to `None` and `None` is dropped before `remove_empty()` is reached, so there is no other way to construct the case that separates the two code paths.

## Open point for review

@SimonStier please take a look at the clearing change as it applies to `src/osw/ontology.py`: `ImportOntologyParam` builds entities from JSON-LD graph nodes and stores them with `overwrite=True`. Under the new behaviour, a node that carries an empty value will clear the value stored on the wiki, where previously it was stripped and the stored value survived. Whether that actually occurs depends on the source ontology, and it is arguably the correct outcome for an authoritative re-import, but you know those import paths best. Not changed in this PR.
